### PR TITLE
Added python file and changed notebook

### DIFF
--- a/CNN_digit_recognizer.ipynb
+++ b/CNN_digit_recognizer.ipynb
@@ -22,19 +22,68 @@
     "colab": {
       "name": "CNN_digit_recognizer.ipynb",
       "provenance": [],
-      "include_colab_link": true
-    }
+      "collapsed_sections": []
+    },
+    "accelerator": "GPU"
   },
   "cells": [
     {
-      "cell_type": "markdown",
+      "cell_type": "code",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "id": "A88gG2Bb7-IH"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/shivamsouravjha/Digit-Recognizer-by-CNN/blob/master/CNN_digit_recognizer.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "# For kaggle API token\n",
+        "# Need to upload API token to runtime\n",
+        "\n",
+        "!mkdir -p ~/.kaggle\n",
+        "!cp kaggle.json ~/.kaggle\n",
+        "\n",
+        "!chmod 600 ~/.kaggle/kaggle.json"
+      ],
+      "execution_count": 1,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "HRLV2EEs7sI0",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "6ce3e292-e344-4918-f4a1-782584a2edec"
+      },
+      "source": [
+        "# For downloading data from Kaggle\n",
+        "\n",
+        "!kaggle competitions download -c digit-recognizer"
+      ],
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Warning: Looks like you're using an outdated API Version, please consider updating (server 1.5.12 / client 1.5.4)\n",
+            "test.csv.zip: Skipping, found more recently modified local copy (use --force to force download)\n",
+            "sample_submission.csv: Skipping, found more recently modified local copy (use --force to force download)\n",
+            "train.csv.zip: Skipping, found more recently modified local copy (use --force to force download)\n"
+          ]
+        }
       ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "AWGDB6P88JDg"
+      },
+      "source": [
+        "import zipfile\n",
+        "with zipfile.ZipFile('train.csv.zip', 'r') as zip_ref:\n",
+        "    zip_ref.extractall()"
+      ],
+      "execution_count": 4,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -42,9 +91,7 @@
         "_uuid": "8f2839f25d086af736a60e9eeb907d3b93b6e0e5",
         "_cell_guid": "b1076dfc-b9ad-4769-8c92-a6c4dae69d19",
         "trusted": true,
-        "id": "quGAm_TeEPMI",
-        "colab_type": "code",
-        "colab": {}
+        "id": "quGAm_TeEPMI"
       },
       "source": [
         "# This Python 3 environment comes with many helpful analytics libraries installed\n",
@@ -57,15 +104,15 @@
         "# Input data files are available in the read-only \"../input/\" directory\n",
         "# For example, running this (by clicking run or pressing Shift+Enter) will list all files under the input directory\n",
         "\n",
-        "import os\n",
-        "for dirname, _, filenames in os.walk('/kaggle/input'):\n",
-        "    for filename in filenames:\n",
-        "        print(os.path.join(dirname, filename))\n",
+        "# import os\n",
+        "# for dirname, _, filenames in os.walk('/kaggle/input'):\n",
+        "#     for filename in filenames:\n",
+        "#         print(os.path.join(dirname, filename))\n",
         "\n",
         "# You can write up to 5GB to the current directory (/kaggle/working/) that gets preserved as output when you create a version using \"Save & Run All\" \n",
         "# You can also write temporary files to /kaggle/temp/, but they won't be saved outside of the current session"
       ],
-      "execution_count": null,
+      "execution_count": 5,
       "outputs": []
     },
     {
@@ -74,15 +121,16 @@
         "_uuid": "d629ff2d2480ee46fbb7e2d37f6b5fab8052498a",
         "_cell_guid": "79c7e3d0-c299-4dcb-8224-4455121ee9b0",
         "trusted": true,
-        "id": "zjVM8FdpEPMN",
-        "colab_type": "code",
-        "colab": {}
+        "id": "zjVM8FdpEPMN"
       },
       "source": [
-        "train= pd.read_csv('/kaggle/input/digit-recognizer/train.csv')\n",
-        "test= pd.read_csv('/kaggle/input/digit-recognizer/test.csv')"
+        "train= pd.read_csv('train.csv')\n",
+        "test= pd.read_csv('test.csv')\n",
+        "\n",
+        "# train= pd.read_csv('/kaggle/input/digit-recognizer/train.csv')\n",
+        "# test= pd.read_csv('/kaggle/input/digit-recognizer/test.csv')"
       ],
-      "execution_count": null,
+      "execution_count": 6,
       "outputs": []
     },
     {
@@ -90,44 +138,586 @@
       "metadata": {
         "trusted": true,
         "id": "zzHlropXEPMS",
-        "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 255
+        },
+        "outputId": "191f94da-f51b-4669-8d6d-d844c82f931d"
       },
       "source": [
-        "\n",
         "train.tail()"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>label</th>\n",
+              "      <th>pixel0</th>\n",
+              "      <th>pixel1</th>\n",
+              "      <th>pixel2</th>\n",
+              "      <th>pixel3</th>\n",
+              "      <th>pixel4</th>\n",
+              "      <th>pixel5</th>\n",
+              "      <th>pixel6</th>\n",
+              "      <th>pixel7</th>\n",
+              "      <th>pixel8</th>\n",
+              "      <th>pixel9</th>\n",
+              "      <th>pixel10</th>\n",
+              "      <th>pixel11</th>\n",
+              "      <th>pixel12</th>\n",
+              "      <th>pixel13</th>\n",
+              "      <th>pixel14</th>\n",
+              "      <th>pixel15</th>\n",
+              "      <th>pixel16</th>\n",
+              "      <th>pixel17</th>\n",
+              "      <th>pixel18</th>\n",
+              "      <th>pixel19</th>\n",
+              "      <th>pixel20</th>\n",
+              "      <th>pixel21</th>\n",
+              "      <th>pixel22</th>\n",
+              "      <th>pixel23</th>\n",
+              "      <th>pixel24</th>\n",
+              "      <th>pixel25</th>\n",
+              "      <th>pixel26</th>\n",
+              "      <th>pixel27</th>\n",
+              "      <th>pixel28</th>\n",
+              "      <th>pixel29</th>\n",
+              "      <th>pixel30</th>\n",
+              "      <th>pixel31</th>\n",
+              "      <th>pixel32</th>\n",
+              "      <th>pixel33</th>\n",
+              "      <th>pixel34</th>\n",
+              "      <th>pixel35</th>\n",
+              "      <th>pixel36</th>\n",
+              "      <th>pixel37</th>\n",
+              "      <th>pixel38</th>\n",
+              "      <th>...</th>\n",
+              "      <th>pixel744</th>\n",
+              "      <th>pixel745</th>\n",
+              "      <th>pixel746</th>\n",
+              "      <th>pixel747</th>\n",
+              "      <th>pixel748</th>\n",
+              "      <th>pixel749</th>\n",
+              "      <th>pixel750</th>\n",
+              "      <th>pixel751</th>\n",
+              "      <th>pixel752</th>\n",
+              "      <th>pixel753</th>\n",
+              "      <th>pixel754</th>\n",
+              "      <th>pixel755</th>\n",
+              "      <th>pixel756</th>\n",
+              "      <th>pixel757</th>\n",
+              "      <th>pixel758</th>\n",
+              "      <th>pixel759</th>\n",
+              "      <th>pixel760</th>\n",
+              "      <th>pixel761</th>\n",
+              "      <th>pixel762</th>\n",
+              "      <th>pixel763</th>\n",
+              "      <th>pixel764</th>\n",
+              "      <th>pixel765</th>\n",
+              "      <th>pixel766</th>\n",
+              "      <th>pixel767</th>\n",
+              "      <th>pixel768</th>\n",
+              "      <th>pixel769</th>\n",
+              "      <th>pixel770</th>\n",
+              "      <th>pixel771</th>\n",
+              "      <th>pixel772</th>\n",
+              "      <th>pixel773</th>\n",
+              "      <th>pixel774</th>\n",
+              "      <th>pixel775</th>\n",
+              "      <th>pixel776</th>\n",
+              "      <th>pixel777</th>\n",
+              "      <th>pixel778</th>\n",
+              "      <th>pixel779</th>\n",
+              "      <th>pixel780</th>\n",
+              "      <th>pixel781</th>\n",
+              "      <th>pixel782</th>\n",
+              "      <th>pixel783</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>41995</th>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>41996</th>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>41997</th>\n",
+              "      <td>7</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>41998</th>\n",
+              "      <td>6</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>41999</th>\n",
+              "      <td>9</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>...</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "<p>5 rows × 785 columns</p>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "       label  pixel0  pixel1  pixel2  ...  pixel780  pixel781  pixel782  pixel783\n",
+              "41995      0       0       0       0  ...         0         0         0         0\n",
+              "41996      1       0       0       0  ...         0         0         0         0\n",
+              "41997      7       0       0       0  ...         0         0         0         0\n",
+              "41998      6       0       0       0  ...         0         0         0         0\n",
+              "41999      9       0       0       0  ...         0         0         0         0\n",
+              "\n",
+              "[5 rows x 785 columns]"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 7
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "RnyxY-fVEPMX",
-        "colab_type": "code",
-        "colab": {}
+        "id": "RnyxY-fVEPMX"
       },
       "source": [
-        "Ytrain= train['label'].astype('float32')\n"
+        "Ytrain= train['label'].astype('float32')"
       ],
-      "execution_count": null,
+      "execution_count": 8,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "QxeFzEQgEPMb",
-        "colab_type": "code",
-        "colab": {}
+        "id": "QxeFzEQgEPMb"
       },
       "source": [
-        "\n",
-        "\n",
         "train= train.drop('label',axis=1)"
       ],
-      "execution_count": null,
+      "execution_count": 9,
       "outputs": []
     },
     {
@@ -135,23 +725,30 @@
       "metadata": {
         "trusted": true,
         "id": "kv4S5giBEPMf",
-        "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "f973dad4-1a2d-4c2d-8f6f-0900768e7305"
       },
       "source": [
-        "\n",
         "print(train.shape[0])"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "42000\n"
+          ]
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "8MyKOl0aEPMj",
-        "colab_type": "code",
-        "colab": {}
+        "id": "8MyKOl0aEPMj"
       },
       "source": [
         "train= train.values.reshape(-1,28,28,1).astype('float32')\n",
@@ -160,16 +757,14 @@
         "train =train / 255.0\n",
         "test = test / 255.0\n"
       ],
-      "execution_count": null,
+      "execution_count": 11,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "UW1mT9dvEPMq",
-        "colab_type": "code",
-        "colab": {}
+        "id": "UW1mT9dvEPMq"
       },
       "source": [
         "from keras.utils.np_utils import to_categorical\n",
@@ -177,46 +772,40 @@
         "from sklearn.model_selection import train_test_split\n",
         "x_train,x_test,y_train,y_test=train_test_split(train,Ytrain,test_size=0.25)"
       ],
-      "execution_count": null,
+      "execution_count": 12,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "ogdD6ICGEPM1",
-        "colab_type": "code",
-        "colab": {}
+        "id": "ogdD6ICGEPM1"
       },
       "source": [
         "from keras.models import Sequential # to create a cnn model\n",
         "from keras.layers import Dense, Dropout, Flatten, Conv2D, MaxPool2D,BatchNormalization\n",
         "from keras.preprocessing.image import ImageDataGenerator\n"
       ],
-      "execution_count": null,
+      "execution_count": 13,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "9JBuLrkxEPM7",
-        "colab_type": "code",
-        "colab": {}
+        "id": "9JBuLrkxEPM7"
       },
       "source": [
         "model = Sequential()"
       ],
-      "execution_count": null,
+      "execution_count": 14,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "j1bvPzfhEPM_",
-        "colab_type": "code",
-        "colab": {}
+        "id": "j1bvPzfhEPM_"
       },
       "source": [
         "model.add(Conv2D(32,(3,3),padding='same',activation= 'relu',input_shape=(28,28,1)))\n",
@@ -226,16 +815,14 @@
         "model.add(MaxPool2D(pool_size=(2,2)))\n",
         "model.add(Dropout(0.2))"
       ],
-      "execution_count": null,
+      "execution_count": 15,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "pKBuGo5jEPNC",
-        "colab_type": "code",
-        "colab": {}
+        "id": "pKBuGo5jEPNC"
       },
       "source": [
         "model.add(Conv2D(64,(3,3),padding='same',activation= 'relu'))\n",
@@ -245,40 +832,26 @@
         "model.add(MaxPool2D(pool_size=(2,2)))\n",
         "model.add(Dropout(0.4))"
       ],
-      "execution_count": null,
+      "execution_count": 16,
       "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YYyrTh2rEPNH",
-        "colab_type": "text"
-      },
-      "source": [
-        ""
-      ]
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "Bjo1As5NEPNI",
-        "colab_type": "code",
-        "colab": {}
+        "id": "Bjo1As5NEPNI"
       },
       "source": [
         "model.add(Flatten())"
       ],
-      "execution_count": null,
+      "execution_count": 17,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "FHnhT83hEPNM",
-        "colab_type": "code",
-        "colab": {}
+        "id": "FHnhT83hEPNM"
       },
       "source": [
         "model.add(Dense(256,activation= 'relu'))\n",
@@ -288,37 +861,33 @@
         "\n",
         "model.add(Dense(10,activation= 'softmax'))"
       ],
-      "execution_count": null,
+      "execution_count": 18,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "yAxnWGObEPNQ",
-        "colab_type": "code",
-        "colab": {}
+        "id": "yAxnWGObEPNQ"
       },
       "source": [
-        "from keras.optimizers import RMSprop,Adam,SGD,Adagrad,Adadelta,Adamax,Nadam\n",
+        "from tensorflow.keras.optimizers import RMSprop,Adam,SGD,Adagrad,Adadelta,Adamax,Nadam\n",
         "\n",
-        "optimizer =Adam(lr=0.004)"
+        "optimizer =Adam(learning_rate=0.004)"
       ],
-      "execution_count": null,
+      "execution_count": 19,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "fQ3U0p1UEPNU",
-        "colab_type": "code",
-        "colab": {}
+        "id": "fQ3U0p1UEPNU"
       },
       "source": [
         "model.compile(optimizer = optimizer , loss = \"categorical_crossentropy\", metrics=[\"accuracy\"])\n"
       ],
-      "execution_count": null,
+      "execution_count": 20,
       "outputs": []
     },
     {
@@ -326,22 +895,78 @@
       "metadata": {
         "trusted": true,
         "id": "lEmNDkf4EPNb",
-        "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "ab0b6fbf-4f12-41ce-9c99-fef3084fe47a"
       },
       "source": [
         "model.summary()"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model: \"sequential\"\n",
+            "_________________________________________________________________\n",
+            "Layer (type)                 Output Shape              Param #   \n",
+            "=================================================================\n",
+            "conv2d (Conv2D)              (None, 28, 28, 32)        320       \n",
+            "_________________________________________________________________\n",
+            "batch_normalization (BatchNo (None, 28, 28, 32)        128       \n",
+            "_________________________________________________________________\n",
+            "conv2d_1 (Conv2D)            (None, 28, 28, 32)        9248      \n",
+            "_________________________________________________________________\n",
+            "batch_normalization_1 (Batch (None, 28, 28, 32)        128       \n",
+            "_________________________________________________________________\n",
+            "max_pooling2d (MaxPooling2D) (None, 14, 14, 32)        0         \n",
+            "_________________________________________________________________\n",
+            "dropout (Dropout)            (None, 14, 14, 32)        0         \n",
+            "_________________________________________________________________\n",
+            "conv2d_2 (Conv2D)            (None, 14, 14, 64)        18496     \n",
+            "_________________________________________________________________\n",
+            "batch_normalization_2 (Batch (None, 14, 14, 64)        256       \n",
+            "_________________________________________________________________\n",
+            "conv2d_3 (Conv2D)            (None, 14, 14, 64)        36928     \n",
+            "_________________________________________________________________\n",
+            "batch_normalization_3 (Batch (None, 14, 14, 64)        256       \n",
+            "_________________________________________________________________\n",
+            "max_pooling2d_1 (MaxPooling2 (None, 7, 7, 64)          0         \n",
+            "_________________________________________________________________\n",
+            "dropout_1 (Dropout)          (None, 7, 7, 64)          0         \n",
+            "_________________________________________________________________\n",
+            "flatten (Flatten)            (None, 3136)              0         \n",
+            "_________________________________________________________________\n",
+            "dense (Dense)                (None, 256)               803072    \n",
+            "_________________________________________________________________\n",
+            "dropout_2 (Dropout)          (None, 256)               0         \n",
+            "_________________________________________________________________\n",
+            "dense_1 (Dense)              (None, 128)               32896     \n",
+            "_________________________________________________________________\n",
+            "dropout_3 (Dropout)          (None, 128)               0         \n",
+            "_________________________________________________________________\n",
+            "dense_2 (Dense)              (None, 10)                1290      \n",
+            "=================================================================\n",
+            "Total params: 903,018\n",
+            "Trainable params: 902,634\n",
+            "Non-trainable params: 384\n",
+            "_________________________________________________________________\n"
+          ]
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
         "id": "P1un2MJ7EPNf",
-        "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "outputId": "50323743-5ff6-4637-a83b-34be42a58714"
       },
       "source": [
         "from tensorflow.keras.utils import plot_model\n",
@@ -350,80 +975,281 @@
         "Image(\"model.png\")\n"
       ],
       "execution_count": null,
-      "outputs": []
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmgAAAgRCAIAAADV0IlZAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nOzde1wTV9o48DOBkEBMuIPIPYmoKIqttILlZbFdtfJR6wWlpd2tl1fU1oiXinihCBSluEJBaCtatxWVe9FFqb5qWZetWrtCVdxqvAKicifhJhDm98f5dTYbIMkAYSI83//mzOTMmZmQhzkz5zwESZIIAAAAANphMd0AAAAA4GUCgRMAAACgAQInAAAAQAMETgAAAIAGQ6YboCuBgYFMNwEAAEa07OxsppugE8P2jjMnJ6eyspLpVgDQpytXrly5coXpVuhcZWVlTk4O060AQ214X3diuA5HIQgiMzNz6dKlTDcEgN7hTpHh+i85JSsra9myZcP1dwb0ZXhf92F7xwkAAADoAgROAAAAgAYInAAAAAANEDgBAAAAGiBwAgAAADRA4ATgZXLmzBlTU9O//e1vTDdkkK1Zs4b43fvvv6+86vz58+Hh4bm5uUKhEG/wwQcfKG8wa9YsPp9vYGAwceLE69evD23D/7+oqCh3d3eBQMDhcMRi8datW5ubm5U3OH78uJeXF5/Pd3Z2Xr58+bNnzxivGevu7k5ISPDx8VEuPHXqVFxcnEKhoEry8/OpC2RlZUVrF8MQOUwhhDIzM5luBQB9WrJkyZIlS+h+qqCgQCAQnDp1ShdN0oXMzExtfmdCQkIsLCwKCwvv3LnT3t5OlUdERMybN08mk+FFkUhkaWmJECooKFD+eGFh4YIFCwa35bT4+fmlpKTU1dXJZLLMzEw2mz1nzhxqbUZGBkIoLi6usbGxpKREKBR6enp2dnYyWzNJknfv3p0xYwZCaMqUKSqrEhMT/fz8Ghoa8GJ3d3dlZeWlS5fmzp1raWmpsWYtr/tLavgeGAROoN/6FziHTGtrq7e398Dr0T5w2tvbqxTu2bPHzc2tra2NKhGJRMeOHWOxWPb29o2NjVQ544EzICCgq6uLWsQjyMvLy/Giv7//mDFjuru78eKBAwcQQsXFxczWXFpaumjRovT0dE9Pz56BkyRJiUTi7e2tEoY3bNgAgRO6agEAvTh8+HB1dTWDDbh3796uXbt2797N5XKVy318fEJDQ588ebJlyxam2tZTQUGBgYEBtYg7M1tbW/FiRUWFnZ0dQRB40dHRESH0+PFjZmueMmVKbm5ucHAwh8PpdYPIyMjS0tLExERtahtRIHAC8NIoLi52cnIiCALfWKSmpvJ4PBMTk5MnT7799tsCgcDBweHEiRN446SkJC6Xa2Njs2bNGjs7Oy6X6+Pjc/XqVbxWIpEYGRmNHj0aL3700Uc8Ho8giNraWoRQaGjo5s2b79+/TxCEWCxGCP3www8CgeCzzz4bsoNNSkoiSXL+/Pk9V8XExLi5uR06dOj8+fO9fpYkyf3790+YMIHD4Zibm7/zzju//fYbXqX+pCGEFApFRESEk5OTsbHx5MmT8Z0TXU+ePDE2NnZ1dcWLQqFQ+b8Q/BhSKBTqVc09mZub+/n5JSYmksN0AqD+Y/iOV2cQdNUC/da/rtqKigqEUHJyMl7csWMHQujChQtNTU3V1dW+vr48Hq+jowOvDQkJ4fF4t2/fbm9vLysrw6+QUL18wcHBtra2VM3x8fEIoZqaGry4ePFikUhErS0oKODz+VFRUXQb3O+uWqFQ6O7urrKZSCR6+PAhSZI//fQTi8VycXFpbm4me3TVRkREGBkZHT16tLGx8caNG6+88oqVldWzZ8/wWvUnbcuWLRwOJycnp6GhYfv27SwW69q1a7QOuaWlhc/nSyQSqqSoqIjNZiclJclkslu3bk2YMGH27Nm06tRpza+//nqvXbUkSYaHhyOESkpKqBLoqiWhqxaAYcDHx0cgEFhbWwcFBbW0tJSXl1OrDA0N8Y2Xu7t7amqqXC4/cuRIP3YREBAgk8l27do1eK1Wp6Wl5eHDhyKRqK8NvL29N27c+OjRo23btqmsamtr279//6JFi95//31TU1MPD4+vvvqqtrb24MGDypv1etLa29tTU1MXLly4ePFiMzOznTt3stlsumcsNjbWzs4uJiaGKvHz8wsLC5NIJAKBYNKkSXK5/NChQ7Tq1HXNfRk7dixC6ObNm4NY5zAAgROA4cPIyAgh1NnZ2evaadOmmZiYUJ2W+qy6upokSRMTEzXbxMTEjBs3LiUlpbi4WLm8rKysubl52rRpVImXl5eRkRHVTa1C+aTduXOntbV10qRJeJWxsfHo0aNpnbG8vLysrKyzZ8/y+XyqcMeOHQcPHrxw4UJzc/ODBw98fHy8vb1x54E+1KwGvgTPnz8frAqHBwicAIwgHA6npqaG6VZo1t7ejhDq66UVjMvlHjlyhCCIFStWtLW1UeWNjY0IoVGjRilvbGZmJpfLNe63paUFIbRz505qzOLjx4+pN3E0ysjI2Lt3b1FRkYuLC1X49OnTuLi41atXz5w5k8fjubq6pqWlVVVV4b5xxmtWz9jYGP1+OQAFAicAI0VnZ2djY6ODgwPTDdEM/14rD8Dvlbe396ZNm6RSaXR0NFVoZmaGEFIJk1oeuLW1NUIoISFB+YHW5cuXtWlzcnJyenr6xYsXx4wZo1wulUoVCoVyoUAgsLCwKCsr06ZandasUUdHB/r9cgCKIdMNAAAMkaKiIpIkp0+fjhcNDQ376tRlnI2NDUEQTU1NGreMjo4uKCgoKSlxcnLCJZMmTRo1atQvv/xCbXP16tWOjo5XX31VY22Ojo5cLre0tJRWa0mS3LZtW0NDQ35+vqGh6o8qDthPnz6lSuRyeX19PR46wlTNWsKXwNbWdrAqHB7gjhOA4ay7u7uhoaGrq+vGjRuhoaFOTk4ffvghXiUWi+vr6/Pz8zs7O2tqalQG/1lYWFRVVT169Egul3d2dhYWFg7lcBQTExOhUFhZWalxS9xhqzzSkcvlbt68OS8vLz09XSaT3bx5c+3atXZ2diEhIdrUtnz58hMnTqSmpspkMoVCUVlZiSNTUFCQra1tr1P63b59+/PPP09LS2Oz2YSSffv2IYRcXV39/f3T0tIuXbrU1tZWUVGBW7Jy5Ur8cUZq1hK+BB4eHv2uYViCwAnAS+PAgQNeXl4IobCwsAULFqSmpiYkJCCEJk+e/ODBg7S0tM2bNyOE5syZI5VK8Ufa29s9PDyMjY19fX3d3Nx+/PFH6sHhunXr/P3933333XHjxkVHR+PuOOrVkrVr19rY2Li7u8+dO7e+vn7oDzYgIKCsrIx6ePn999+LxeL79+97eXmtX79eecvp06dv2rRJueTTTz+NjY2NioqysrLy8/NzcXEpKiri8XgIIY0nLTExcePGjXFxcZaWlnZ2dqGhoQ0NDQihjo6O6urqkydP9mwqqXaYI0EQ2dnZQUFBK1euNDc3d3d3Ly8vz83N9fX1xRswUjNC6MqVK2+88caYMWOuXr3666+/2tnZzZgx49KlS8rbXLt2zd7efvLkyWqaMRIN/QiYoYFgHCfQb0Mw5R6eAFanu9Co3+M4pVKpoaHh0aNHddY0ehQKha+v7+HDh0dOzbW1tVwud9++fcqFMI6ThHGcAAxvGt+v0R9tbW1nz56VSqX4hRSxWBwVFRUVFaWSDIQRCoUiPz9fLpcHBQWNnJojIyM9PT0lEglCiCTJqqqq4uLie/fuDWozX0oQOAEAeqG+vn7OnDlubm4rVqzAJeHh4YGBgUFBQdq8JaRTRUVFubm5hYWF6oeWDqea9+/fX1paeubMGTabjRA6efKkvb29r6/v6dOnB7edLyWmb3l1BellV+3u3bsnTJjA5/ONjIxEItEnn3wil8t73XLlypV4IJryZFdqnD59Wt+yTV2+fHn8+PF4+mkbG5vo6Ogh23VOTg41maetrW1wcPCQ7Vp7uu6qDQ8Px0P7XVxcsrOzdbcj9QbeZXf27NmwsLDBag/QRn5+fmxsrHJWFrqGd1ft8D0wvQyc6lPrqcATT2sZOPU2TePs2bMRQlRWv6EkEolMTU2Hfr9a0vO0YoNleP+Agr4M7+sOXbVDatSoUfh9DT6fv3Tp0oULF/7www+DMj9WQEBAU1PTvHnzBl6Vem1tbSrJ4vWE3jYMADDMwAQIQ6qgoEB5USW1ngoqx55eYTxNY1/0tmEAgGFmpN9xHj16dNq0aVwul8fjubi44Im7yP4m85swYQJBECwW69VXX8XhcOvWraamplwu969//WvPvauk1iNJMj4+fty4cRwOx9TU9JNPPtHyKF6WNI1D2TBt/OMf/3B3d8cXyMPD4+zZswihVatW4THmIpGopKQEIbR8+XITExNTU9NTp06hPvI1fv755yYmJnw+v7q6evPmzfb29nfu3NGyGQCAlwzTfcW6grR4xonHQe/Zs6eurq6+vv7rr7/Gb5H0O5lfV1eXi4uLk5OT8kP1jRs3qkx9ifVMrbdjxw6CIP7yl780NDS0trampKQgrZ9x6m2aRpVnnEPWMFKLZ5zZ2dmRkZH19fV1dXXTp0+nRqctXrzYwMDgyZMn1Jbvvfce9fy4r3yN+NA2bNiQnJy8aNGif//732p2TcIzTjCsDe/rPnLvODs7O3fv3u3v779t2zYLCwtzc/OVK1d6eXkNJJmfgYHBhg0bysvL8/Ly8Gatra25ubnU6/XKVFLrtbW1JSQkvPXWW5s2bTIzMzM2NrawsBjgMeptmsYhaJg2lixZ8umnn5qbm1tYWMyfP7+urg5nDlm7dq1CoaD2K5PJrl27NnfuXKRFvsa9e/d+/PHHubm548eP11GzAQDMGrnPOG/cuNHY2IjvhzAc9n755Zd+J/NDCK1atSoyMjIxMTEwMBAhlJ6e/s477wgEApVP4dR6586do1Lr3bt3r7W19c033xy8Q+yzkSoYTNOoPw3Dg9XwdAEzZ850c3P75ptvtm/fThBERkZGUFAQng114PkaleXk5Ojnk+xBN0IOE4wQIzdwymQy9HsGImUDSeaHP7h69er4+Piff/75tdde+/LLL3NyclS2ycjI2L9/f1FRkXI+IDyZMs5qNPT0Nk2jTht2+vTp+Pj4srIymUymHLwJglizZs2mTZsuXLjw1ltvfffdd8eOHcOrqHyNO3fupLa3s7PrXwOmT5++cePGARzBS+Dy5cuJiYm44w6MHPi6M90KXRm5gRMHLfxqibKBJPPDJBJJYmJiQkLC2rVrHR0dRSKR8trk5OSzZ89evHhRJTZzuVyE0IsXL2gexyDQ2zSNumjYpUuX/vWvf23cuLG8vHzhwoWLFi365ptvxowZk5ycvHXrVmqzDz/8cPv27YcOHXJ0dBQIBM7OzricytcYGho68MY4ODgsXbp04PXoucTExJFwmEDFMA6cI/cZp4uLi4WFxblz51TKB5LMD8O/hjk5Obt27VL+eSVJMiws7ObNm/n5+SpRE++XxWL9/e9/79fRDIjepmnURcP+9a9/4SwZN2/e7OzsXLdunVAo5HK5Kn2J5ubmy5Yty8/P37dv3//+7/9S5f3L1wgAGE5GbuDkcDjbt2+/dOmSRCJ58uRJd3e3XC6/ffv2QJL5UTZv3tzV1dXQ0DBz5kyqUH1qPWtr68WLF+fk5Bw+fFgmk924cUPldaTBpbdpGgerYT1r7uzsfP78OZVeCuc9Pn/+fHt7u1Qq7fkMe+3atS9evCgoKFCeVkJNvkYAwEjB8Fu9OoO0m3LvwIEDHh4eXC6Xy+VOnTo1JSWFJMnu7u74+PixY8ey2Wxzc/OFCxfeuXMHb5+SkoJnTB47duz9+/cPHjyIX/xxdna+e/eucs3+/v6HDh1SLrl582avlyA+Ph5vIJfLV61aZWlpOWrUqDfeeCMiIgIh5ODg8Ouvv6o/iuTkZDzA0cTEZP78+RobGRISwmaz7e3tDQ0NBQLBO++8c//+faq2uro6f39/Lpfr6uq6fv16PJxULBbjYSHXr193dnY2NjZ+4403nj17dubMGT6fHxMT07NVV65cmThxIovFQgiNHj36s88+G7KGffnllyo95Mry8vJwhWFhYRYWFmZmZoGBgXgIrEgkoka/kCQ5derU8PBwleN68eJFWFiYk5OToaEh/nenrKwsLi4O57N0dHTUMhMWDEcBw9jwvu4EqTZR6suLIIjMzEx4stKrNWvWZGdn19XVMd0QVfrWsICAgAMHDlAzVAwu/N51dna2LirXH1lZWcuWLRuuvzOgL8P7uo/crtoRTm/TNDLeMKqb98aNG/jultn2AAD0DQTOl8Bvv/1G9G3Q89+OcGFhYVKp9O7du8uXL8dTMIIhsGbNGuor/f777yuvOn/+fHh4eG5urlAoxBt88MEHyhvMmjWLz+cbGBhMnDjx+vXrQ9vw/y8qKsrd3V0gEHA4HLFYvHXrVpX828ePH8czYTk7Oy9fvvzZs2eM14x1d3cnJCSoJEg4depUXFyc8n+x+fn51AXCk2yPaAx3FesM0su0YvpAT9I09qQnDduxYweLxXJ0dNR1jjZ4xqkMZw0qLCy8c+dOe3s7VR4RETFv3jyZTIYXRSKRpaUlQqigoED544WFhQsWLBjcltOiPmNgRkYGQiguLq6xsbGkpEQoFHp6enZ2djJbM0mSd+/enTFjBkJoypQpKqsSExP9/PyoyTK7u7srKysvXbo0d+5canJKNYb3M87he2AQOIF+G4LA2dra6u3tzWxV2gdOe3t7lcI9e/a4ubm1tbVRJSKR6NixYywWy97evrGxkSpnPHAGBAQoz1CN366gXjTz9/cfM2ZMd3c3XsRvohUXFzNbc2lp6aJFi9LT0z09PXsGTpIkJRKJt7e3ShjesGEDBE7oqgVg2BrEVGtDn7Xt3r17u3bt2r17N54bhOLj4xMaGvrkyZMtW7YMZXvUKygowJMyYioZAysqKuzs7Kixwo6OjgghlfFUQ1/zlClTcnNzg4ODORxOrxtERkaWlpYO43kM+g0CJwB6jew7yR2tVGsMppPrn6SkJJIk58+f33NVTEyMm5vboUOHzp8/3+tn1Zw09bntUB9p4+hSyRgoFAqV/+3AjyGFQqFe1dyTubm5n59fYmIiOUxfju0/Zm94dQdBVy3Qb1p21apPckcr1dpQppOj9LurVigUuru7q2wmEokePnxIkuRPP/3EYrFcXFyam5vJHl21/c4MSPadNk57PTMGFhUVsdnspKQkmUx269atCRMmzJ49m1adOq359ddf77WrliTJ8PBw9N/JDaGrloSuWgD0mZZJ7rTHbDo57bW0tDx8+FDNLBbe3t4bN2589OjRtm3bVFYNJDOgxrRx2lDJGIgQ8vPzCwsLk0gkAoFg0qRJcrn80KFDtOrUdc19GTt2LEKor8lbRiwInADor7KyMlpJ7mhhMJ2cRtXV1SRJ4nmm+hITEzNu3LiUlJTi4mLlcronTTm33cDTxuGMgWfPnqUyBiKEduzYcfDgwQsXLjQ3Nz948MDHx8fb2xsnn9eHmtXAl+D58+eDVeHwAIETAP01wCR3GultOrn29naEUF8vrWBcLvfIkSMEQaxYsaKtrY0qH8hJo9LGUWMWHz9+TL2Jo1FGRsbevXuLiopcXFyowqdPn8bFxa1evXrmzJk8Hs/V1TUtLa2qqgp3hjNes3p4Ikl8OQAFAicA+mvgSe7U0Nt0cuj332uN00h5e3tv2rRJKpUqT1UxkJNGpY1TfqB1+fJlbdqcnJycnp5+8eJF5Ty7CCGpVKpQKJQLBQKBhYVFWVmZNtXqtGaNOjo60O+XA1BGbj5OAPSfxiR3A0m1prfp5BBCNjY2BEE0NTVp3DI6OrqgoKCkpASnu0EDywzYv7RxJElu27atoaEhPz/f0FD1RxUHbOUUOnK5vL6+Hg8dYapmLeFLYGtrO1gVDg9wxwmA/tKY5I5uqjW9TSenwsTERCgUVlZWatwSd9gqj3QcSGZANWnjgoKCbG1te53ST33GQFdXV39//7S0tEuXLrW1tVVUVOCWrFy5En+ckZq1hC+Bh4dHv2sYliBwAqDXPv3009jY2KioKCsrKz8/PxcXFyqlKEJo3bp1/v7+77777rhx46Kjo3GXGvV6yNq1a21sbNzd3efOnVtfX48Qam9v9/DwMDY29vX1dXNz+/HHH6nniHSr0rWAgICysjLq4eX3338vFovv37/v5eW1fv165S2nT5++adMm5RI1Jy01NTUhIQEhNHny5AcPHqSlpW3evBkhNGfOHKlUihBKTEzcuHFjXFycpaWlnZ1daGhoQ0MDQqijo6O6uvrkyZM9m0qqHeZIEER2dnZQUNDKlSvNzc3d3d3Ly8tzc3N9fX3xBozUjBC6cuXKG2+8MWbMmKtXr/766692dnYzZsy4dOmS8jbXrl2zt7efPHmymmaMREM/AmZoIBjHCfTb0M9Vi+eDHco9kgMYxymVSg0NDbVMbjoEFAqFr6/v4cOHR07NtbW1XC533759yoUwjpOEcZwAjCiMZ21To62t7ezZs1KpFL+QIhaLo6KioqKiVJKBMEKhUOTn58vl8kFPRqTPNUdGRnp6ekokEoQQSZJVVVXFxcX37t0b1Ga+lCBwAgD0Qn19/Zw5c9zc3FasWIFLwsPDAwMDg4KCtHlLSKeKiopyc3MLCwvVDy0dTjXv37+/tLT0zJkzbDYbIXTy5El7e3tfX9/Tp08PbjtfSkzf8uoKgq5aoN+GuKuWqaxtA++yO3v2bFhY2GC1B2gjPz8/NjZWOSsLXcO7qxaGowAwIsTGxsbGxjLdiv6YNWvWrFmzmG7FyLJgwYIFCxYw3Qr9BV21AAAAAA0QOAEAAAAaIHACAAAANEDgBAAAAGgYzi8HaTk1MwCMwJOZZWVlMd0Q3cJ/hsP+MIGK4f3zS5Bqp3R6eREEwXQTAABgRBu28WW4HhgAL7WlS5ciuFEDQC/BM04AAACABgicAAAAAA0QOAEAAAAaIHACAAAANEDgBAAAAGiAwAkAAADQAIETAAAAoAECJwAAAEADBE4AAACABgicAAAAAA0QOAEAAAAaIHACAAAANEDgBAAAAGiAwAkAAADQAIETAAAAoAECJwAAAEADBE4AAACABgicAAAAAA0QOAEAAAAaIHACAAAANEDgBAAAAGiAwAkAAADQAIETAAAAoAECJwAAAEADBE4AAACABgicAAAAAA0QOAEAAAAaIHACAAAANEDgBAAAAGiAwAkAAADQAIETAAAAoAECJwAAAEADBE4AAACABoIkSabbAABAx44dO3z4cHd3N158+PAhQsjV1RUvslislStXBgcHM9Y+AMDvIHACoBdu3LgxZcoUNRv8+uuvkydPHrL2AAD6AoETAH0xfvz4O3fu9LpKLBZLpdIhbg8AoFfwjBMAffHBBx+w2eye5Ww2e/ny5UPfHgBAr+COEwB98eDBA7FY3OufpFQqFYvFQ98kAEBPcMcJgL4QCoWvvPIKQRDKhQRBTJs2DaImAPoDAicAeuRPf/qTgYGBcomBgcGf/vQnptoDAOgJumoB0CPV1dV2dnbUoBSEEIvFqqqqsrW1ZbBVAABlcMcJgB6xsbHx8/OjbjoNDAz+8Ic/QNQEQK9A4ARAv3zwwQfK/UAffPABg40BAPQEXbUA6BeZTGZtbd3R0YEQYrPZ1dXVZmZmTDcKAPAfcMcJgH4RCARz5swxNDQ0NDScO3cuRE0A9A0ETgD0zvvvv69QKBQKBUxOC4Aegq5aAPROe3u7lZUVSZK1tbXGxsZMNwcA8F8gcA5IVlbWsmXLmG4FAADQkJmZuXTpUqZb8RIzZLoBw0FmZibTTQCDbNmyZaGhod7e3kw1oLS0lCAI9flSBi4hIQEhtHHjRp3uBegV+F9/4CBwDgL43234WbZsmbe3N4NXdtGiRQghQ0Pd/oVmZ2cj+AKPMBA4Bw4CJwD6SNchEwDQb/BWLQAAAEADBE4AAACABgicAAAAAA0QOAEAAAAaIHACMGjOnDljamr6t7/9jemGDJHz58+Hh4fn5uYKhUKCIAiCUJmSftasWXw+38DAYOLEidevX2ekkVFRUe7u7gKBgMPhiMXirVu3Njc3K29w/PhxLy8vPp/v7Oy8fPnyZ8+eMV4z1t3dnZCQ4OPjo1x46tSpuLg4hUJBqyowyEgwAHgEJ9OtAIMPIZSZmUn3UwUFBQKB4NSpU7poki4sWbJkyZIl/ftsRETEvHnzZDIZXhSJRJaWlgihgoIC5c0KCwsXLFgw0IYOgJ+fX0pKSl1dnUwmy8zMZLPZc+bModZmZGQghOLi4hobG0tKSoRCoaenZ2dnJ7M1kyR59+7dGTNmIISmTJmisioxMdHPz6+hoUHLqlT077sNlMGP/oBA4Byu9PzHpbW11dvbe+D19Dtw7tmzx83Nra2tjSoRiUTHjh1jsVj29vaNjY1UOeOBMyAgoKuri1rEg1bLy8vxor+//5gxY7q7u/HigQMHEELFxcXM1lxaWrpo0aL09HRPT8+egZMkSYlE4u3trX0YVqbn3+2XAnTVAvDyOXz4cHV1NVN7v3fv3q5du3bv3s3lcpXLfXx8QkNDnzx5smXLFqba1lNBQQGVGBwhZGVlhRBqbW3FixUVFXZ2dgRB4EVHR0eE0OPHj5mtecqUKbm5ucHBwRwOp9cNIiMjS0tLExMTtakNDDoInAAMjuLiYicnJ4Ig8L1Famoqj8czMTE5efLk22+/LRAIHBwcTpw4gTdOSkricrk2NjZr1qyxs7Pjcrk+Pj5Xr17FayUSiZGR0ejRo/HiRx99xOPxCIKora1FCIWGhm7evPn+/fsEQYjFYoTQDz/8IBAIPvvss6E50qSkJJIk58+f33NVTEyMm5vboUOHzp8/3+tnSZLcv3//hAkTOByOubn5O++889tvv+FV6s8YQkihUERERDg5ORkbG0+ePLl/U10+efLE2NjY1dUVLwqFQuV/QfBjSKFQqFc192Rubu7n55eYmEjCZOOMYPiO9yUHXbXDFepXd1ZFRQVCKDk5GS/u2LEDIXThwoWmpqbq6mXdUosAACAASURBVGpfX18ej9fR0YHXhoSE8Hi827dvt7e3l5WV4bdIqI6+4OBgW1tbqub4+HiEUE1NDV5cvHixSCSi1hYUFPD5/KioKLoN7l9XrVAodHd3VykUiUQPHz4kSfKnn35isVguLi7Nzc1kj67aiIgIIyOjo0ePNjY23rhx45VXXrGysnr27Bleq/6MbdmyhcPh5OTkNDQ0bN++ncViXbt2jVbLW1pa+Hy+RCKhSoqKithsdlJSkkwmu3Xr1oQJE2bPnk33hOiu5tdff73XrlqSJMPDwxFCJSUldOvs33cbKIM7TgB0y8fHRyAQWFtbBwUFtbS0lJeXU6sMDQ3xvZe7u3tqaqpcLj9y5Eg/dhEQECCTyXbt2jV4re5TS0vLw4cPRSJRXxt4e3tv3Ljx0aNH27ZtU1nV1ta2f//+RYsWvf/++6amph4eHl999VVtbe3BgweVN+v1jLW3t6empi5cuHDx4sVmZmY7d+5ks9l0T1dsbKydnV1MTAxV4ufnFxYWJpFIBALBpEmT5HL5oUOHaNWp65r7MnbsWITQzZs3B7FOoCUInAAMESMjI4RQZ2dnr2unTZtmYmJC9VvqrerqapIkTUxM1GwTExMzbty4lJSU4uJi5fKysrLm5uZp06ZRJV5eXkZGRlQftQrlM3bnzp3W1tZJkybhVcbGxqNHj6Z1uvLy8rKyss6ePcvn86nCHTt2HDx48MKFC83NzQ8ePPDx8fH29sY9B/pQsxr4Ejx//nywKgTag8AJgL7gcDg1NTVMt0KD9vZ2hFBfL61gXC73yJEjBEGsWLGira2NKm9sbEQIjRo1SnljMzMzuVyucb8tLS0IoZ07dxK/e/z4MfUmjkYZGRl79+4tKipycXGhCp8+fRoXF7d69eqZM2fyeDxXV9e0tLSqqircMc54zerhDOf4coAhBoETAL3Q2dnZ2Njo4ODAdEM0wL/XGgfge3t7b9q0SSqVRkdHU4VmZmYIIZUwqeVRW1tbI4QSEhKUHzVdvnxZmzYnJyenp6dfvHhxzJgxyuVSqVShUCgXCgQCCwuLsrIybarVac0adXR0oN8vBxhikLoIAL1QVFREkuT06dPxoqGhYV+dusyysbEhCKKpqUnjltHR0QUFBSUlJU5OTrhk0qRJo0aN+uWXX6htrl692tHR8eqrr2qszdHRkcvllpaW0motSZLbtm1raGjIz8/vmakNB+ynT59SJXK5vL6+Hg8dYapmLeFLYGtrO1gVAu3BHScAjOnu7m5oaOjq6rpx40ZoaKiTk9OHH36IV4nF4vr6+vz8/M7OzpqaGpXxfxYWFlVVVY8ePZLL5Z2dnYWFhUM2HMXExEQoFFZWVmrcEnfYKo905HK5mzdvzsvLS09Pl8lkN2/eXLt2rZ2dXUhIiDa1LV++/MSJE6mpqTKZTKFQVFZW4sgUFBRka2vb65R+t2/f/vzzz9PS0thsNqFk3759CCFXV1d/f/+0tLRLly61tbVVVFTglqxcuRJ/nJGatYQvgYeHR79rAP3HxKu8wwcMRxmuEP1X9pOTk/HISxMTk/nz56ekpODXN8aOHXv//v2DBw8KBAKEkLOz8927d0mSDAkJYbPZ9vb2hoaGAoHgnXfeuX//PlVbXV2dv78/l8t1dXVdv379J598ghASi8V4vMr169ednZ2NjY3feOONZ8+enTlzhs/nx8TE0D3M/g1HkUgkbDa7tbUVL+bl5eGXbK2srD7++GOVjT/55BPl4Sjd3d3x8fFjx45ls9nm5uYLFy68c+cOXqXxjL148SIsLMzJycnQ0NDa2nrx4sVlZWUkSS5cuBAhFBER0bOpfb10Gh8fjzeora0NDQ0Vi8UcDmfUqFEzZsz4/vvvqY8zUjNJkpcvX54xY4adnR2uc/To0T4+Pn//+9+VtwkICLC3t6dmJtJeP77bQAX86A8IBM7hagh+XEJCQiwsLHS6C436FzilUqmhoeHRo0d10aR+UCgUvr6+hw8fHjk119bWcrncffv29eOzEDgHDrpqAWDMS5rjQiwWR0VFRUVFqSQDYYRCocjPz5fL5UFBQSOn5sjISE9PT4lEMrgNA1qCwDk8aUx4RFm1ahWfzycIgtZrF3fu3Fm/fv3EiRP5fL6hoaGpqambm1tAQICWbzkOhJpDU85vhRkZGdnY2PzhD3+Ij49vaGjQddtGjvDw8MDAwKCgIG3eEtKpoqKi3NzcwsJC9UNLh1PN+/fvLy0tPXPmDJvNHtyGAW0xfcv7ctPbrlr1CY9U4OlAtZ+769ChQ2w2+3/+539++OGHhoaG9vb2+/fvZ2Rk+Pj4fP3114N0BH3SeGgikcjU1JQkSfzqzY8//vjhhx8SBGFnZ6f9DG1Ix91Z4eHheHS/i4tLdna27nak3kDSipEkefbs2bCwsEFsD9AoPz8/NjZWOSsLXbr+bo8E+vij/xLR28CpPuGRClqB8/LlywYGBjNnzuyZ0uiHH36gpmnVHY2HRgVOZdnZ2SwWy8bGRjnjlRoj5MdlgIETvIxGyHdbp6CrdnhSn/BIBZX5SBsxMTEKhWLPnj09x67Nnj37448/pt9YemgdGmXJkiUffvhhdXX1V199pdv2AQCGOwicQ+To0aPTpk3jcrk8Hs/FxQVPp0L2N8XShAkTCIJgsVivvvoqjhlbt241NTXlcrl//etfe+5dJeERSZLx8fHjxo3jcDimpqZ4qANFTY6qjo6OCxcuWFpavvbaa+qPl6lDUwMPkSwsLNS4JQAAqMPwHe9LTsuu2oSEBITQnj176urq6uvrv/766+DgYHIAKZa6urpcXFycnJyUOy03btyoMiEZ1jPh0Y4dOwiC+Mtf/tLQ0NDa2pqSkoKUumrV5Ki6e/cuQmj69OkaD5mpQyP76KolSVImkyGEHB0dNTaeHDHdWdBVOwKNkO+2TkHgHBBtAmdHR4eZmZm/vz9V0tXVlZiY2NraOmrUqKCgIKr8559/RghREQtHl7a2NryIw9u9e/fwIg7GWVlZeLGlpcXJyampqalnA3bs2OHm5iaTyfBia2uriYnJH//4R2oD7Z9x4snS3nrrLfWbMXVoWF+BkyRJgiDMzMw0HiY5Yn5cIHCOQCPku61TMFetzt24caOxsXH27NlUiYGBwYYNG3755Zd+p1hCCK1atSoyMjIxMTEwMBAhlJ6e/s477+CZVpThhEfnzp2jEh7du3evtbX1zTff7Mex4LwWGh8oDiR71EAOTb2WlhaSJHvW05chGFrDODxtW1ZWFtMNAeBlAoFT53APIc4LoWwgKZbwB1evXh0fH//zzz+/9tprX375ZU5Ojso2GRkZ+/fvLyoqUs7SgH8rca4JulxcXLhcLu6wVYOpQ1MPN3v8+PFabp+YmJiYmKjlxi+1ZcuWMd0EAF4m8HKQzuFf9traWpXygaRYwvCUoQkJCZcuXXJ0dMTzhVL6SnjE5XIRQi9evKB5HAghxOFwZs+eXVtb+89//rPn2vr6+lWrViHmDk29H374ASH09ttva7n9SOjOgq7aEUj7PxnQFwicOufi4mJhYXHu3DmV8oGkWMIcHByWLl2ak5Oza9eu0NBQqpwkybCwsJs3b+bn56vc9uH9slisv//97/06GhQZGcnhcDZt2qScoBi7desWHqPC1KGp8ezZs4SEBAcHhxUrVmj/KQAA6AkCp85xOJzt27dfunRJIpE8efKku7tbLpffvn17ICmWKJs3b+7q6mpoaJg5cyZVqD7hEU4rkZOTc/jwYZlMduPGjYMHDyrXqT5Hlaen57Fjx27duuXr63vmzJmmpqbOzs6HDx+mpaWtXLkSzwHG1KFRSJJsbm7GiSNqamoyMzNnzJhhYGCQn5+v/TNOAADoHbOdBi877WcOOnDggIeHB5fL5XK5U6dOTUlJIQeWYoni7+9/6NAh5RKNCY/kcvmqVassLS1HjRr1xhtvREREIIQcHBx+/fVXkiS1yVFVXl6+ZcsWDw+PUaNGGRgYmJmZTZ06deXKlf/85z/xBowc2qlTpyZPnmxiYmJkZMRisRBC+DXa1157LSoqqq6uTpsrhSHoqgXD1Aj5busUQUKX9wBkZWUtW7YMzuHwQxBEZmYmns9vGMPvLWdnZzPdEDB0Rsh3W6egqxYAAACgAQInAAAAQAMETgCAts6fPx8eHq6c9/SDDz5Q3mDWrFl8Pt/AwGDixInXr19npJEak9EeP37cy8uLz+c7OzsvX7782bNnjNccFxc3fvx4Y2NjHo83fvz4Xbt24fHfGvd76tSpuLi4lzQj+kuM6YesLze9TSsGBgiNjBcoaL0cFBERMW/ePGqCQ5FIZGlpiRAqKChQ3qywsHDBggWD3FA61GdszcjIQAjFxcU1NjaWlJQIhUJPT8+eOfKGuOaAgIB9+/ZVV1fL5fKsrCw2m608Kab6/SYmJvr5+TU0NGizI3LEfLd1Cn70BwQC53Cl6x+X1tZWb29vxqvSPnDu2bPHzc2Nml6YJEmRSHTs2DEWi2Vvb6+c5ZTxwKk+Y6u/v/+YMWPwUCWSJA8cOIAQKi4uZrbmhQsXKp9b/NJWVVWVNvslSVIikXh7e2sZpCFwDhx01QLAgMOHD1dXV+tbVX25d+/erl27du/ejaedovj4+ISGhj558mTLli06bQAt6jO2VlRU2NnZUTloHR0dEUKPHz9mtua8vDzlc2tvb48QovpjNeagjYyMLC0tHSEzROoDCJwA9BPZd85RiURiZGQ0evRovPjRRx/xeDyCIPDMi6GhoZs3b75//z5BEGKxOCkpicvl2tjYrFmzxs7Ojsvl+vj4UBPi06oKqU2n2m9JSUkkSc6fP7/nqpiYGDc3t0OHDp0/f57uWVKfmRUhpFAoIiIinJycjI2NJ0+ejDt46FLJ2CoUCpX/z8CPIYVCoV7VLJVKzczMnJ2dtdkvQsjc3NzPzy8xMZGEoXFDg9kb3pcddNUOV0iL7iz1OUeDg4NtbW2pjePj4xFCNTU1eHHx4sUikYhaGxISwuPxbt++3d7eXlZWhl8wofriaFWlJp1qT1p21QqFQnd3d5VCkUj08OFDkiR/+uknFovl4uLS3NxM9uiq7XdmVpIkt2zZwuFwcnJyGhoatm/fzmKxrl27ps1xUXpmbC0qKmKz2UlJSTKZ7NatWxMmTJg9ezatOnVXc0dHR2VlZXJyMofDOXr0qJb7xcLDw5F2yQG1+W4D9eBHf0AgcA5XGn9cNOYcpRs4lXOIXrt2DSG0e/fuflRFizaBs7m5mSCIefPmqZRTgZMkyc2bNyOEPv74Y/K/A+dAMrO2tbWZmJhQn21tbeVwOOvWraN1gL1mbN25cyd15+Dg4FBRUUGrTt3VbGtrixCytLT84osvqP8etNkvSZLffPMNQui7777TuBcInAMHXbUA9AfdnKO0TJs2zcTEhOrSZFZ1dTVJkniWxL7ExMSMGzcuJSWluLhYuXwgmVnv3LnT2to6adIkvMrY2Hj06NG0zgnO2Hr27FnljK07duw4ePDghQsXmpubHzx44OPj4+3tXVFRoX21uqu5oqKiurr6+PHj33777dSpU3s+uu51vxi+QM+fP6d1IKB/IHAC0B8DzDmqEYfDqampGZSqBqi9vR0hxOFw1GzD5XKPHDlCEMSKFSuU0+YM5Cy1tLQghHbu3ElN5f/48WONSdQpGRkZe/fuLSoqcnFxoQqfPn0aFxe3evXqmTNn8ng8V1fXtLS0qqoqfBPPeM1sNtva2nrWrFkZGRllZWWxsbEa90sxNjZGv18soGsQOAHoj4HnHFWjs7NzsKoaOPyLrHGIvbe396ZNm6RSaXR0NFU4kLOEc60nJCQod5FdvnxZmzb3lbFVKpUqFArlQoFAYGFhUVZWpk21Oq1ZmVgsNjAwUP6sxhy0HR0d6PeLBXQNAicA/aEx56ihoSHucuyHoqIikiSnT58+8KoGzsbGhiCIpqYmjVtGR0ePHz++pKSEKhlIZlZHR0cul1taWkqrtaTajK04YD99+pQqkcvl9fX1eOgIUzXX1dW99957yiU4DOPPqt8vBV8g/JQU6BoETgD6Q2POUbFYXF9fn5+f39nZWVNTozKez8LCoqqq6tGjR3K5HAfF7u7uhoaGrq6uGzduhIaGOjk5ffjhh/2oSn061X4wMTERCoWVlZUat8QdtsojDgeSmZXL5S5fvvzEiROpqakymUyhUFRWVuLIFBQUZGtr2+uUfuoztrq6uvr7+6elpV26dKmtra2iogK3ZOXKlfjjjNTM4/HOnTt38eJFmUzW2dlZUlLy5z//mcfjbdq0SeN+KfgCeXh4aDyxYOAgcALQT59++mlsbGxUVJSVlZWfn5+Li0tRURGPx8Nr161b5+/v/+67744bNy46Ohr3oVFvi6xdu9bGxsbd3X3u3Ln19fUIofb2dg8PD2NjY19fXzc3tx9//JF6rEi3qkEXEBBQVlZGPbz8/vvvxWLx/fv3vby81q9fr7zl9OnT8c+9NmcpNTU1ISEBITR58uQHDx6kpaXht3PnzJkjlUoRQomJiRs3boyLi7O0tLSzswsNDW1oaEAIdXR0VFdXnzx5smdTSbUDGQmCyM7ODgoKWrlypbm5ubu7e3l5eW5urq+vL96AkZq5XO6MGTNWrVplb2/P5/MDAwNdXFyuXLmCX4xSv1/KtWvX7O3tJ0+erM3GYKCG+jXe4QWGowxXaGhf2Q8JCbGwsBiy3VG0HMcplUoNDQ37Glk49BQKha+v7+HDh6FmrLa2lsvl7tu3T5uNh/i7PSzBHScAekGfE1yIxeKoqKioqCiVZCCMUCgU+fn5crk8KCgIasYiIyM9PT0lEokuKgc9QeAEAGgWHh4eGBgYFBSkzVtCOlVUVJSbm1tYWKh+aOkIqRkhtH///tLS0jNnzrDZ7EGvHPQKAicADNu+ffuRI0eamppcXV1zcnKYbk6fPvvsM4lEsmfPHmab8eabbx47doyavHeE13zy5MkXL14UFRWZm5sPeuWgL4ZMNwCAkS42NlZlqLvemjVr1qxZs5huBfiPBQsWLFiwgOlWjDhwxwkAAADQAIETAAAAoAECJwAAAEADBE4AAACABng5aBAEBgYy3QQw+BISErKzs5luhW5duXIFwRcYAJoIUrv5nECvLl++vH//fqZbAYYhPFX61KlTmW4IGIY2bdrk7e3NdCteYhA4AdBHS5cuRQhlZWUx3RAAgCp4xgkAAADQAIETAAAAoAECJwAAAEADBE4AAACABgicAAAAAA0QOAEAAAAaIHACAAAANEDgBAAAAGiAwAkAAADQAIETAAAAoAECJwAAAEADBE4AAACABgicAAAAAA0QOAEAAAAaIHACAAAANEDgBAAAAGiAwAkAAADQAIETAAAAoAECJwAAAEADBE4AAACABgicAAAAAA0QOAEAAAAaIHACAAAANEDgBAAAAGiAwAkAAADQAIETAAAAoAECJwAAAEADBE4AAACABgicAAAAAA0QOAEAAAAaIHACAAAANEDgBAAAAGgwZLoBAACEEGptbX3x4gW12NHRgRBqaGigSjgcjomJCQMtAwD8N4IkSabbAABAqampH330kZoNUlJS1q1bN2TtAQD0BQInAHqhpqbGzs5OoVD0utbAwODp06fW1tZD3CoAQE/wjBMAvWBtbf3mm28aGBj0XGVgYPDWW29B1ARAT0DgBEBfvP/++732AJEk+f777w99ewAAvYKuWgD0hVwut7a2Vn5FCDMyMqqpqREIBIy0CgCgAu44AdAXfD5/3rx5bDZbudDQ0HDBggUQNQHQHxA4AdAjwcHBXV1dyiUKhSI4OJip9gAAeoKuWgD0SEdHh5WVlVwup0pGjRpVW1vL4XAYbBUAQBnccQKgR4yMjAIDA42MjPAim81etmwZRE0A9AoETgD0y3vvvYenDUIIdXZ2vvfee8y2BwCgArpqAdAv3d3do0ePrqmpQQhZWVk9e/as18GdAACmwB0nAPqFxWK99957RkZGbDY7ODgYoiYA+gYCJwB659133+3o6IB+WgD0E43sKJWVlT/99JPumgIAwEiStLS0RAg9fPjw0aNHTDcHgOHPx8fHwcFB261JrWVmZuqy2QAAAAAzMjMztY+GtPNxwstEAAyB27dvI4Tc3d2Zbsh/EASRmZm5dOlSphuiW4GBgQih7OxsphsChg5BELS2h0TWAOgjvQqZAABl8HIQAAAAQAMETgAAAIAGCJwAAAAADRA4AQAAABogcAIAAAA0QOAEAOjQmTNnTE1N//a3vzHdEF05f/58eHh4bm6uUCgkCIIgiA8++EB5g1mzZvH5fAMDg4kTJ16/fp2RRkZFRbm7uwsEAg6HIxaLt27d2tzcrLzB8ePHvby8+Hy+s7Pz8uXLnz17xnjNcXFx48ePNzY25vF448eP37Vrl0wm02a/p06diouLUygUWu6oP+hOgKD99gCA4QTRHCSOFRQUCASCU6dO6aJJurBkyZIlS5ZouXFERMS8efNkMhleFIlEeMqngoIC5c0KCwsXLFgwyA2lw8/PLyUlpa6uTiaTZWZmstnsOXPmUGszMjJwoGpsbCwpKREKhZ6enp2dnczWHBAQsG/fvurqarlcnpWVxWaz//jHP2q538TERD8/v4aGBm12RNL/bkPgBABopX+Bc8i0trZ6e3sPvB7tA+eePXvc3Nza2tqoEpFIdOzYMRaLZW9v39jYSJUzHjgDAgK6urqoRTyLRXl5OV709/cfM2ZMd3c3Xjxw4ABCqLi4mNmaFy5cqHxu8cQUVVVV2uyXJEmJROLt7a1lkKb73YauWgDAcHD48OHq6uoh2929e/d27dq1e/duLperXO7j4xMaGvrkyZMtW7YMWWM0KigoUE6zY2VlhRBqbW3FixUVFXZ2dtTsOY6Ojgihx48fM1tzXl6e8rm1t7dHCFH9ser3ixCKjIwsLS1NTEzUZl90QeAEAOhKcXGxk5MTQRD4ViM1NZXH45mYmJw8efLtt98WCAQODg4nTpzAGyclJXG5XBsbmzVr1tjZ2XG5XB8fn6tXr+K1EonEyMho9OjRePGjjz7i8XgEQdTW1iKEQkNDN2/efP/+fYIgxGIxQuiHH34QCASfffaZjg4tKSmJJMn58+f3XBUTE+Pm5nbo0KHz58/3+lmSJPfv3z9hwgQOh2Nubv7OO+/89ttveJX6U4QQUigUERERTk5OxsbGkydP7t8U4k+ePDE2NnZ1dcWLQqFQ+X8O/BhSKBTqVc1SqdTMzMzZ2Vmb/SKEzM3N/fz8EhMTSV1ME6v9zSl01QIwkqF+ddVWVFQghJKTk/Hijh07EEIXLlxoamqqrq729fXl8XgdHR14bUhICI/Hu337dnt7e1lZGX6phOp/Cw4OtrW1pWqOj49HCNXU1ODFxYsXi0Qiam1BQQGfz4+KiqLbYC27aoVCobu7u0qhSCR6+PAhSZI//fQTi8VycXFpbm4me3TVRkREGBkZHT16tLGx8caNG6+88grOWI7Xqj9FW7Zs4XA4OTk5DQ0N27dvZ7FY165do3WALS0tfD5fIpFQJUVFRWw2OykpSSaT3bp1a8KECbNnz6ZVp+5q7ujoqKysTE5O5nA4R48e1XK/WHh4OEKopKRE417ofrchcAIAtDKIgZN6dpWSkoIQunfvHl4MCQkxNTWlPnvt2jWE0O7du/EircDZb9oEzubmZoIg5s2bp1JOBU6SJDdv3owQ+vjjj8n/Dpytra2jRo0KCgqiPvXzzz8jhKgYr+YUtbW1mZiYUJ9tbW3lcDjr1q2jdYA7duxwc3OjXmjCdu7cSd1NOTg4VFRU0KpTdzXb2toihCwtLb/44gvqvwdt9kuS5DfffIMQ+u677zTuhe53G7pqAQCMMTIyQgh1dnb2unbatGkmJiZUN6b+qK6uJknSxMREzTYxMTHjxo1LSUkpLi5WLi8rK2tubp42bRpV4uXlZWRkRHVKq1A+RXfu3GltbZ00aRJeZWxsPHr0aFrnJy8vLysr6+zZs3w+nyrcsWPHwYMHL1y40Nzc/ODBAx8fH29vb/wfD+M1V1RUVFdXHz9+/Ntvv506dWrPx9i97hfDF+j58+e0DkQbEDgBAPqLw+HU1NQw3QpV7e3tCCEOh6NmGy6Xe+TIEYIgVqxY0dbWRpU3NjYihEaNGqW8sZmZmVwu17jflpYWhNDOnTuJ3z1+/Fj5jRj1MjIy9u7dW1RU5OLiQhU+ffo0Li5u9erVM2fO5PF4rq6uaWlpVVVV+Iae8ZrZbLa1tfWsWbMyMjLKyspiY2M17pdibGyMfr9YgwsCJwBAT3V2djY2Njo4ODDdEFX4F1njEHtvb+9NmzZJpdLo6Giq0MzMDCGkEia1PExra2uEUEJCgnK34eXLl7Vpc3Jycnp6+sWLF8eMGaNcLpVKFQqFcqFAILCwsCgrK9OmWp3WrEwsFhsYGCh/tq/9Ujo6OtDvF2twQeAEAOipoqIikiSnT5+OFw0NDfvq1B1iNjY2BEE0NTVp3DI6Onr8+PElJSVUyaRJk0aNGvXLL79QJVevXu3o6Hj11Vc11ubo6MjlcktLS2m1liTJsLCwmzdv5ufnq9zpIoRwwH769ClVIpfL6+vr8dARpmquq6t77733lEtwGMafVb9fCr5A+Cnp4ILACQDQI93d3Q0NDV1dXTdu3AgNDXVycvrwww/xKrFYXF9fn5+f39nZWVNTozIc0MLCoqqq6tGjR3K5vLOzs7CwUHfDUUxMTIRCYWVlpcYtcYet8ohDLpe7efPmvLy89PR0mUx28+bNtWvX2tnZhYSEaFPb8uXLT5w4kZqaKpPJFApFZWUljkxBQUG2tra9Tul3+/btzz//PC0tjc1mE0r27duHEHJ1dfX3909LS7t06VJbW1tFRQVuycqVK/HHGamZx+OdO3fu4sWLMpmss7OzpKTkz3/+M4/H27Rpk8b9UvAF8vDw0Hhi8VydgAAAIABJREFU6YLACQDQlQMHDnh5eSGEwsLCFixYkJqampCQgBCaPHnygwcP0tLS8Kunc+bMkUql+CPt7e0eHh7Gxsa+vr5ubm4//vgj9Shx3bp1/v7+77777rhx46Kjo3EXHPWyydq1a21sbNzd3efOnVtfX6/rQwsICCgrK6MeXn7//fdisfj+/fteXl7r169X3nL69On4557y6aefxsbGRkVFWVlZ+fn5ubi4FBUV8Xg8hJDGU5SYmLhx48a4uDhLS0s7O7vQ0NCGhgaEUEdHR3V19cmTJ3s2lVQ7kJEgiOzs7KCgoJUrV5qbm7u7u5eXl+fm5vr6+uINGKmZy+XOmDFj1apV9vb2fD4/MDDQxcXlypUr+MUo9fulXLt2zd7efvLkydpsTI/2L+DCcBQARjKk+yn3QkJCLCwsdLoLjbQcxymVSg0NDfsaWTj0FAqFr6/v4cOHoWastraWy+Xu27dPm43pfrfhjhMAoEd0m9Ri8IjF4qioqKioKJVkIIxQKBT5+flyuTwoKAhqxiIjIz09PSUSiS4qH+TA6eXlZWBg4OnpObjVYsuXL+dyuQRB6OL14qG3b98+/IrBV199hUsGNwHT0KRzUs6mhBkaGlpZWb311lt5eXmDtRf1l17PMzoNjwsNegoPDw8MDAwKCtLmLSGdKioqys3NLSwsVD+0dITUjBDav39/aWnpmTNn2Gz2oFeOBj1wXrt2zd/ff3DrpBw5ckSv5k0eoC1btvz000/KJeSgzqk4uLX1ZfHixQ8ePBCJRNSELzU1NZmZmU+ePFm8eHH/JtLsSf2lp9pgaWmZnp5++vRpatW5c+eys7PnzZtXVlb2yiuvDEpj6BoeF3oIbN++/ciRI01NTa6urjk5OUw3RyufffaZRCLZs2cPs8148803jx07Rk3kO8JrPnny5IsXL4qKiszNzQe9ckwnXbXUXPjaa2tr8/Hx0UVjXiIBAQFNTU3z5s3r38dVzuEAa+s3c3PzN99884svvkAIZWVladx+EC99UlISi8UKCQlh/A5AveFxoQddbGzsixcvSJJ8+PDhkiVLmG6OtmbNmrV3716mWwH+Y8GCBeHh4cpvMg86nQTOftwd00oJ1I/APBIMcVol9fBEHniSFPUG8dLrZ0anQadXFxqAEUgngfPevXvjx4/n8Xj4nXLlqRr/8Y9/uLu7m5qacrlcDw+Ps2fPot5SAiGEjh49Om3aNC6Xy+PxXFxcqKk3WCzW6dOn3377bVNTUzs7OzyNr0Yak/WQfSf6+fzzz01MTPh8fnV19ebNm+3t7deuXcvj8Vgs1quvvmpra8tms3k83iuvvOLr64tHKJuZmW3dulX9UatQScB07949oof/+7//0/IcqtSm/gA1npx+ZGi6ceMGQsjPz0/9SRj0Sz+QjE5woQEAWtH+BVwth6O8+eabQqHw4cOHnZ2dt27dev3117lc7t27d/Ha7OzsyMjI+vr6urq66dOnW1pa4nKVzAZ4JNOePXvq6urq6+u//vrr4OBgUinhTmNjY319/dy5czkcTktLizbtV5+sR5tEPxs2bEhOTl60aNG///3vTz/9FCF09erVlpaW2traOXPmIIROnz5dU1PT0tKCX+UqLS1Vf9R4YNaXX36JF5XzSEil0m3btuFDe/r0qbm5uY+Pj0Kh0P4cqmSlGEgmI40ZmpSfcba2thYWFjo7O8+aNQvnVBqaSz+IGZ1G7IVWD+l+OIo+0HI4ChhO6H63dRI4p0yZQi3iO48tW7b03BJP14vzDCj/FnR0dJiZmfn7+1NbdnV14XykKgl3vvvuO4TQrVu3tGm/mmQ9dBP9kCSJf0/lcjle/PbbbxFCN2/eVP54RkaG+qNW83uqbOHChVwu97ffflNfm5rf04FkMtKGSCRS+YfMw8Pj22+/xY+stG/2QC69LjI6kXChlUDgBMMV3e+2Yf/uU7Xn4eFhamqKw6cK/Ci057CtGzduNDY2zp49myoxMDDYsGFDXzX0b/pK5WQ9dBP99FVbV1eXxob1ddR9ycrK+v777+Pi4saNG9fv2gaSyUhLpqam+IlmV1fX8+fPz507J5FIYmNji4uLraystGz2YF36mJiYgoKClJSUZcuWKZfDhVZB90InJCRkZ2drufFL6sqVKwihwMBAphsC9NdQTIDAZrOpv8zTp0//4Q9/sLa25nA4yg+HlMlkMvR7DoGhMZBEP9rQ5qh7VVdXt379ei8vL3wL1e/adH2AygwNDe3t7ZcvX75v3747d+5Qb+oP5aXXRUYnbYyoCw3AiKXzO86urq76+nonJyeEUHl5+cKFCxctWvTNN9+MGTMmOTm5158DnCOmtrZW122jDCTRj0ZaHnWvNmzY0NjYePHiRerV6v7VptMD7AueW/n27duIiUuPMzrt27cvOjoaf/0QXOgB27hx49KlSwelKr2F7zWH/Y01UEZ3pIbO7zh//PHH7u5uPPb85s2bnZ2d69atEwqFeCKYXj/i4uJiYWFx7tw5XbeNMpBEPxppedQ9nT59+tixY7t27Zo4cSIu+eSTT/pXm04PsC//+te/EEK445GRSz+4GZ00GrEXGoCRRieBs6Ojo6mpqaur6/r16xKJxNnZGScGwv/4nz9/vr29XSqVKj93UU4JxGKxtm/ffunSJYlE8uTJk+7ubrlcjm9cdGQgiX40UnPUashksjVr1nh6em7btg0h1N7e/ssvv5SWlmp5DlWeWg3wALXM0NTW1tbd3U2SZFVV1ZEjR3bu3GllZbVx40b1J0F3l35wMzppNAwuNABAK9q/R6TlW7VHjhzx9/e3sbExNDS0tLR89913Hz9+TK0NCwuzsLAwMzMLDAzEI89EIlF5efn169ednZ2NjY3feOMN/Or8gQMHPDw8uFwul8udOnVqSkpKXFwcTiQ0duzY+/fvp6en4xmVHBwcNL5Ym5KSgmdExJ89ePCgQCBACDk7O+OhMt3d3fHx8WPHjmWz2ebm5gsXLrxz5w7+LLVfR0dHnAwhMTER1+bi4vKPf/xj7969pqamCCFbW9tjx45lZGTg1Knm5uYnTpzo66hDQ0PxZjweb9GiRcnJyXj2KRMTk/nz56sklsPmzp2r5TncuXOncm3qD1DjyTlz5gyfz4+Jiel5YvPy8nq+UsvhcMaOHbtu3bry8vIhuPRUG6ysrPCbtMo++eQT5eEocKHVXGj1ELxVC4Yput9tgtR6osusrKxly5Zpvz0AYDghCCIzMxOecYLhh+53G9KKAQAAADQMk8D522+/9Zy3jKKjfG8AAHD+/Pnw8HA9z20XFRXl7u4uEAg4HI5YLN66datKGtHjx497eXnx+XxnZ+fly5c/e/aM8Zrj4uLGjx9vbGzM4/HGjx+/a9cuPFxN435PnToVFxen28Su2vfqavmMEwAwLCF4xtlDRETEvHnzZDIZXsS57RBCBQUFypupzPs49Pz8/FJSUurq6mQyWWZmJpvNnjNnDrU2IyMDB6rGxsaSkhKhUOjp6dnZ2clszQEBAfv27auurpbL5VlZWWw2+49//KOW+01MTPTz82toaNBmR6Q+TLkHABiWdB04W1tbvb29Ga9K+8C5Z88eNzc35QkaRSLRsWPHWCyWvb19Y2MjVc544AwICOjq6qIW8cM86t09f3//MWPG4FfiSZLEb6IVFxczW/PChQuVzy1+9lxVVaXNfkmSlEgk3t7eWgZput/tYdJVCwB42Q1iurQhyLx27969Xbt27d69m8vlKpfrZ267goIC5XFZeBbM1tZWvFhRUWFnZ0eNFXZ0dEQIPX78mNma8/LylM+tvb09Qojqj1W/X4RQZGRkaWlpYmKiNvuiCwInAGDQkH0nNZNIJEZGRnjwDELoo48+4vF4BEHgiaJU0qUlJSVxuVwbG5s1a9bY2dlxuVwfHx9qMCutqlC/8uJplJSURJLk/Pnze64aSG47janfFApFRESEk5OTsbHx5MmTcUcgXU+ePDE2NnZ1dcWLQqFQ+f8M/BhSKBTqVc1SqdTMzMzZ2Vmb/SKEzM3N/fz8cIqIfuxOA+1vTqGrFoCRDGnRnaU+qVlwcLCtrS21cXx8PEKopqYGL6pkfQkJCeHxeLdv325vby8rK8MvmFB9cbSq0pgXT5mWXbVCodDd3V2lcBBz2/WV+m3Lli0cDicnJ6ehoWH79u0sFuvatWvaHBelpaWFz+dLJBKqpKioiM1mJyUlyWSyW7duTZgwYfbs2bTq1F3NHR0dlZWVycnJHA4Hj67WZr9YeHg4QqikpETjXrT5bv/X9tpvCoETgJFM44+LxqRmdAMnleSVJMlr164hhHbv3t2PqmjRJnA2NzcTBDFv3jyVcl3ktlNO/dbW1mZiYkJ9trW1lcPhrFu3jtYB7tixw83NjXqhCdu5cyd1N+Xg4FBRUUGrTt3VjCcPsbS0/OKLL/pKHNvrfkmSxLnuv/vuO417oRs4oasWADA4Bp61TY1p06aZmJhQXZrMwolR8TRMfYmJiRk3blxKSkpxcbFy+UBSv925c6e1tXXSpEl4lbGx8ejRo2mdk7y8vKysrLNnz/L5fKpwx44dBw8evHDhQnNz84MHD3x8fLy9vXGeV8ZrrqioqK6uPn78+Lfffjt16tSej6573S+GL9Dz589pHYg2IHACAAaHrpOacTicmpqaQalqgNrb2xFCHA5HzTa6yG3X0tKCENq5cyc1SP3x48fKb8Sol5GRsXfv3qKiIhcXF6rw6dOncXFxq1evnjlzJo/Hc3V1TUtLq6qqwjfxjNfMZrOtra1nzZqVkZFRVlaGM7qr3y8Fz6CJL9bggsAJABgcOk1q1tnZqetEeNrDv8gah9jj3HZSqTQ6OpoqHMhZsra2RgglJCQodxtevnxZmzYnJyenp6dfvHgRJ++jSKVShUKhXCgQCCwsLMrKyrSpVqc1KxOLxQYGBsqf7Wu/lI6ODvT7xRpcEDgBAINDY1IzQ0NDlXQu2isqKiJJcvr06QOvauBsbGwIgmhqatK45eDmtvt/7N17QBNX3jfwM0BIIIT7RUS5hIhIBbWVVnB5KHWLVh61boui9qLVp1RbKV6qi7cqWiyFFQpid6XWbb1xVbRUqo8X1nWr1j6FqvjU4qUKouVOuJYQ5v3jvJ0nGzDJACGxfD9/OWcm55yZjPkxZ2bOb+TIkSKRqLS0lFdvWZZdu3bt1atXCwoK1K50CSE0YD948IAraW5urq+vp6+OGKrmurq6+fPnq5bQMEw/q7ldDv2C6F3SgYXACQADQ2tSM5lMVl9fX1BQoFAoampq1N7n65kurbu7u6Ghoaur68qVK7Gxse7u7jRBId+qdMyLpztLS0upVFpZWal1y4HNbScSiRYtWnTo0KFdu3bJ5XKlUllZWUkjU1RUlIuLS69T+l2/fv2jjz7KzMwUCASqc5HSzDxeXl5hYWGZmZnnzp1rb2+vqKigPVm8eDH9uEFqFovFJ0+ePHPmjFwuVygUJSUlr7/+ulgsXrlypdZ2OfQL8vf313pg+ULgBIAB8/777yckJMTHxzs6OoaGhnp6ehYXF4vFYrp22bJlYWFh8+bNGz169NatW+kYGve0yNKlS52dnf38/KZPn15fX08I6ejo8Pf3t7CwCAkJ8fHxOXv2LHdbkW9VAy4iIqKsrIy7eXnkyBGZTHbr1q3AwMDly5erbjlp0iT6c6/LUdq1a1dKSgohJCAg4Pbt25mZmfTp3GnTppWXlxNCUlNTV6xYkZiY6ODg4OrqGhsb29DQQAjp7Oysrq4+evRoz66yGl9kZBgmNzc3Kipq8eLFdnZ2fn5+9+7dy8/PDwkJoRsYpGaRSDR58uQlS5a4ublJJJLIyEhPT8+LFy/SB6M0t8u5fPmym5tbQECALhvzo/sDuHgdBWAoI4M7V210dLS9vf2gNcfR8T3O8vJyMzOzR71ZOPiUSmVISMiePXtQM1VbWysSiZKTk3XZmO+5jStOADBS+k1w0T8ymSw+Pj4+Pl4tGYhBKJXKgoKC5ubmAc8E9TjWTG3evHn8+PExMTH6qByBEwCgL+Li4iIjI6OionR5SkiviouL8/Pzi4qKNL9aOkRqJoTs2LGjtLT0+PHjAoFgwCsnCJwAYITWrVu3d+/epqYmLy+vvLw8Q3fnkT744IOYmJjt27cbthtTpkw5cOAAN3nvEK/56NGjv/76a3FxsZ2d3YBXTpnpqV4AgD5LSEhQe9XdaIWHh4eHhxu6F/B/Zs2aNWvWLL02gStOAAAAHhA4AQAAeEDgBAAA4AGBEwAAgAcETgAAAB54P1XLMIw++gEAxm/u3Llz5841dC8GA37oQAOG1W3SP0JIZWXlN998o9feAABFJyxdsWKFoTsCMCQEBwfrnrSOR+AEgEEzZ84cQkhOTo6hOwIA6nCPEwAAgAcETgAAAB4QOAEAAHhA4AQAAOABgRMAAIAHBE4AAAAeEDgBAAB4QOAEAADgAYETAACABwROAAAAHhA4AQAAeEDgBAAA4AGBEwAAgAcETgAAAB4QOAEAAHhA4AQAAOABgRMAAIAHBE4AAAAeEDgBAAB4QOAEAADgAYETAACABwROAAAAHhA4AQAAeEDgBAAA4AGBEwAAgAcETgAAAB4QOAEAAHhA4AQAAOABgRMAAIAHBE4AAAAeEDgBAAB4QOAEAADgwczQHQAAQgi5dOnSDz/8wC3evn2bELJ7926uZNy4cc8884wBegYA/45hWdbQfQAAUlhYOGPGDFNTUxMTE0II/Y/JMAwhpLu7W6lUfvnll//5n/9p4F4CAAIngJFQKBSOjo5yubzXtdbW1jU1Nebm5oPcKwDoCfc4AYyCQCCYN29er6FRwyoAGHwInADGYt68eZ2dnT3LFQrF/PnzB78/ANArDNUCGIvu7u7hw4f/8ssvauVOTk4PHz6k9z4BwODwXxHAWJiYmLz66qtqQ7Lm5uYLFy5E1AQwHvjfCGBEeo7WdnZ2zps3z1D9AYCeMFQLYFxGjRp18+ZNblEqld66dcuA/QEANbjiBDAur7zyikAgoP82Nzd//fXXDdsfAFCDK04A43Lz5s1Ro0Zxizdu3PDx8TFgfwBADa44AYyLTCYbN24cwzAMw4wbNw5RE8DYIHACGJ3XXnvN1NTU1NT0tddeM3RfAEAdhmoBjE5VVdXIkSNZlq2oqHBzczN0dwDg3yBwanHhwoUdO3YYuhcw5BQXFxNCnn32WQP3A4aelStXBgUFGboXRg1DtVpUVFTk5eUZuhdgXPLy8iorK/XahLu7u4eHh16b0OrixYsXL140bB9gkOXl5VVUVBi6F8YO+Th1kpuba+gugBFhGGbFihVz5szRXxP19fWEEHt7e/01oVVkZCTByT/E0Ex2oBkCJ4AxMmzIBAANMFQLAADAAwInAAAADwicAAAAPCBwAgAA8IDACTBIjh8/bmNj8+WXXxq6I/py6tSpuLi4/Px8qVRKpwx89dVXVTcIDw+XSCSmpqZPPPHE999/b5BOxsfH+/n5WVtbC4VCmUy2Zs2alpYW1Q0OHjwYGBgokUg8PDwWLVr08OFDg9ecmJjo6+trYWEhFot9fX03btwol8t1affYsWOJiYlKpVLHhkBXLGiUnZ2NowRqCCHZ2dl8P1VYWGhtbX3s2DF9dEkfXn755ZdfflnHjTdt2jRjxgy5XE4Xvb29HRwcCCGFhYWqmxUVFc2aNWuAO8pHaGhoRkZGXV2dXC7Pzs4WCATTpk3j1mZlZRFCEhMTGxsbS0pKpFLp+PHjFQqFYWuOiIhITk6urq5ubm7OyckRCATPP/+8ju2mpqaGhoY2NDTo0hDb13N7qEFI0AKBE3oy8h+Xtra2oKCg/teje+Dcvn27j49Pe3s7V+Lt7X3gwAETExM3N7fGxkau3OCBMyIioquri1ukL+Peu3ePLoaFhQ0fPry7u5su7ty5kxBy/vx5w9Y8e/Zs1WNL36+tqqrSpV2WZWNiYoKCgnQM0kZ+bhsJDNUC/N7s2bOnurp60Jq7efPmxo0bt2zZIhKJVMuDg4NjY2Pv37+/evXqQeuMVoWFhaamptyio6MjIaStrY0uVlRUuLq6cpMAjBw5khBy9+5dw9Z8+PBh1WNLpy/mxmM1t0sI2bx5c2lpaWpqqi5tgS4QOAEGw/nz593d3RmGoZcau3btEovFlpaWR48efeGFF6ytrUeMGHHo0CG6cVpamkgkcnZ2fuutt1xdXUUiUXBw8KVLl+jamJgYc3PzYcOG0cW3335bLBYzDFNbW0sIiY2NXbVq1a1btxiGkclkhJCvv/7a2tr6gw8+0NOupaWlsSw7c+bMnqu2bdvm4+Pz6aefnjp1qtfPsiy7Y8eOMWPGCIVCOzu7F1988ccff6SrNB8iQohSqdy0aZO7u7uFhUVAQAAdHOLr/v37FhYWXl5edFEqlar+zUFvQ0qlUqOquby83NbW9lEzMqq1Swixs7MLDQ1NTU1lMTP5QDHwFa/Rw1At9ET6NJxFpwBNT0+ni+vXryeEnD59uqmpqbq6OiQkRCwWd3Z20rXR0dFisfj69esdHR1lZWX0oRJu/G3BggUuLi5czUlJSYSQmpoauvjSSy95e3tzawsLCyUSSXx8PN8O6zhUK5VK/fz81Aq9vb3v3LnDsuw333xjYmLi6enZ0tLC9hiq3bRpk7m5+b59+xobG69cufLkk086Ojo+fPiQrtV8iFavXi0UCvPy8hoaGtatW2diYnL58mVeO9ja2iqRSGJiYriS4uJigUCQlpYml8uvXbs2ZsyYqVOn8qpTfzV3dnZWVlamp6cLhcJ9+/bp2C4VFxdHCCkpKdHaSt/O7aEGIUELBE7oaQADJ3fvKiMjgxBy8+ZNuhgdHW1jY8N99vLly4SQLVu20EVegbPPdAmcLS0tDMPMmDFDrZwLnCzLrlq1ihDyzjvvsP8eONva2qysrKKiorhPffvtt4QQLsZrOETt7e2WlpbcZ9va2oRC4bJly3jt4Pr16318fLgHmqgNGzZw1xUjRoyoqKjgVaf+anZxcSGEODg4fPzxx9xfD7q0y7LsZ599Rgj54osvtLaCwKkLDNUCGAVzc3NCiEKh6HXtxIkTLS0tuWFM41FdXc2yrKWlpYZttm3bNnr06IyMjPPnz6uWl5WVtbS0TJw4kSsJDAw0NzfnBqXVqB6iGzdutLW1jR07lq6ysLAYNmwYr+Nz+PDhnJycEydOSCQSrnD9+vW7d+8+ffp0S0vL7du3g4ODg4KC+GYL0VPNFRUV1dXVBw8e/PzzzydMmNDzNnav7VL0C/rll1947Qg8CgInwONBKBTW1NQYuhfqOjo6CCFCoVDDNiKRaO/evQzDvPHGG+3t7Vx5Y2MjIcTKykp1Y1tb2+bmZq3ttra2EkI2bNjA/Obu3buqT8RolpWV9eGHHxYXF3t6enKFDx48SExMfPPNN5977jmxWOzl5ZWZmVlVVUUv6A1es0AgcHJyCg8Pz8rKKisrS0hI0Noux8LCgvz2ZUH/IXACPAYUCkVjY+OIESMM3RF19BdZ6yv2QUFBK1euLC8v37p1K1doa2tLCFELkzruppOTEyEkJSVFdQDtwoULuvQ5PT19//79Z86cGT58uGp5eXm5UqlULbS2tra3ty8rK9OlWr3WrEomk5mamqp+9lHtcjo7O8lvXxb0HwInwGOguLiYZdlJkybRRTMzs0cN6g4yZ2dnhmGampq0brl161ZfX9+SkhKuZOzYsVZWVt999x1XcunSpc7OzqeeekprbSNHjhSJRKWlpbx6y7Ls2rVrr169WlBQoHalSwihAfvBgwdcSXNzc319PX11xFA119XVzZ8/X7WEhmH6Wc3tcugXRO+SQv8hcAIYqe7u7oaGhq6uritXrsTGxrq7uy9cuJCukslk9fX1BQUFCoWipqZG7XVAe3v7qqqqn3/+ubm5WaFQFBUV6e91FEtLS6lUWllZqXVLOmCr+sahSCRatWrV4cOH9+/fL5fLr169unTpUldX1+joaF1qW7Ro0aFDh3bt2iWXy5VKZWVlJY1MUVFRLi4uvU7pd/369Y8++igzM1MgEDAqkpOTCSFeXl5hYWGZmZnnzp1rb2+vqKigPVm8eDH9uEFqFovFJ0+ePHPmjFwuVygUJSUlr7/+ulgsXrlypdZ2OfQL8vf313pgQRcInACDYefOnYGBgYSQtWvXzpo1a9euXSkpKYSQgICA27dvZ2Zm0kdPp02bVl5eTj/S0dHh7+9vYWEREhLi4+Nz9uxZ7lbismXLwsLC5s2bN3r06K1bt9IhOO5hk6VLlzo7O/v5+U2fPr2+vl7fuxYREVFWVsbdvDxy5IhMJrt161ZgYODy5ctVt5w0aRL9uee8//77CQkJ8fHxjo6OoaGhnp6excXFYrGYEKL1EKWmpq5YsSIxMdHBwcHV1TU2NrahoYEQ0tnZWV1dffTo0Z5dZTW+yMgwTG5ublRU1OLFi+3s7Pz8/O7du5efnx8SEkI3MEjNIpFo8uTJS5YscXNzk0gkkZGRnp6eFy9epA9GaW6Xc/nyZTc3t4CAAF02Bu0G+zHexw1eR4GeiP4f2Y+Ojra3t9drE1rp+B5neXm5mZnZo94sHHxKpTIkJGTPnj2omaqtrRWJRMnJybpsPAjn9u8ArjgBjNTjktRCJpPFx8fHx8erJQMxCKVSWVBQ0NzcHBUVhZqpzZs3jx8/PiYmRh+VD00InADQX3FxcZGRkVFRUbo8JaRXxcXF+fn5RUVFml8tHSI1E0J27NhRWlp6/PhxgUAw4JUPWQicjyutyf84S5YskUgkDMPwegSxu7s7JSUlODi4D327cePG8uXLn3jiCYlEYmZmZmNj4+PjExERoePbAv2h4bCo5omkzM3NnZ2dn3322aSkJHp7zEisW7du7969TU1NXl5eeXl5hu6OTj744IOYmJjt27cbthtTpkw5cOAAN5HvEK/56NGyXJrdAAAgAElEQVSjv/76a3FxsZ2d3YBXPqQZeqzY2BntPU7NSfjU0KmxdZmpkvrpp58mT55MCBk3bhzfjn366acCgeA//uM/vv7664aGho6Ojlu3bmVlZQUHB//tb3/jWxtfWg+Lt7c3ncqOPrN69uzZhQsXMgzj6uqq+0ynZGjcB+KVjxN+H4bIud1PZgaN2tB3VlZW0dHR9OH+OXPm5Ofn5+TkVFRU6PJmmGY//PBDfHz80qVLW1tbWZ7pFC5evBgdHR0aGnrixAkzs/9/dkmlUqlUamtryz0vqj+6HxaGYWxtbZ999tlnn302IiJi7ty5ERERP/30k42Njb47CQCPNQzVPq60JuFTxWUB1MW4cePy8/MXLFigeR61Xm3btk2pVG7fvp2LmpypU6e+8847fCvki9dh4bz88ssLFy6srq7+61//qt/+AcDjD4FzwOzbt2/ixIkikUgsFnt6etKpxdi+phscM2YMwzAmJiZPPfUU/d1fs2aNjY2NSCT6+9//3rN1tSR8LMsmJSWNHj1aKBTa2Ni89957A7WbGpI7dnZ2nj592sHB4emnn9ZciaEOiwZ0boGioiKtWwLAUGfYkWLjp+M9Tvqm9vbt2+vq6urr6//2t78tWLCA7Ue6wa6uLk9PT3d3966uLq6VFStWqE3OSfVMwrd+/XqGYf7yl780NDS0tbXRfEy63+OknnnmmZ73ODUkd/zpp58IIZMmTdJas6EOC6tyj1ONXC4nhIwcOVJr59khcx8I9ziHoCFybvcTAqcWugTOzs5OW1vbsLAwrqSrqys1NbU/6QbZ34JxTk4OXWxtbXV3d29qaurZAbUkfG1tbZaWls8//zy3Ad+Hg6heA6cGdNLRP/7xj5o3M9RhoR4VOFmWpXc9te/nkPlxQeAcgobIud1PGKodAFeuXGlsbJw6dSpXYmpq+u677/Yn3SAhZMmSJTY2NqmpqXRx//79L774orW1tdqneibhu3nzZltb25QpUwZo/3RF55jWekPRUIdFM/okVM96HmXu3LnM711eXl5eXp6hewGDSsfzf4jDU7UDgI7y0RxJqvqTbpB+8M0330xKSvr222+ffvrpTz75pOcrfVlZWTt27CguLlZNJ0QndKZ5lwaTp6enSCSiA7YaGOqwaEa77evrq+P2sbGxQUFBOm78mKIX9ytWrDB0R2DwzJ0719BdeAwgcA4A+utcW1urVt6fdINUTExMampqSkrK0qVLR44c6e3trbo2PT39xIkTZ86cUQtCIpGIEPLrr7/y3I/+EgqFU6dOPXr06L/+9S/6Gqiq+vr6NWvWfPrpp4Y6LJp9/fXXhJAXXnhBx+2DgoLmzJmje/2Po9zcXELI7343QRUCpy4wVDsAPD097e3tT548qVben3SD1IgRI+bMmZOXl7dx48bY2FiunNWYhG/s2LEmJib/+Mc/+rQ3/bJ582ahULhy5UouVwbn2rVr9B0VQx0WDR4+fJiSkjJixIg33nhD908BwNCEwDkAhELhunXrzp07FxMTc//+/e7u7ubm5uvXr/cn3SBn1apVXV1dDQ0Nzz33HFeoOQmfk5PTSy+9lJeXt2fPHrlcfuXKld27dw/UzmpO7jh+/PgDBw5cu3YtJCTk+PHjTU1NCoXizp07mZmZixcvprNlGuqwcFiWbWlp6e7uZlm2pqYmOzt78uTJpqamBQUFut/jBIChy6CPJj0GdJ9yb+fOnf7+/iKRSCQSTZgwISMjg2XZ7u7upKSkUaNGCQQCOzu72bNn37hxg26fkZFB53QeNWrUrVu3du/eTX+1PTw8fvrpJ9Waw8LCPv30U9WSq1ev9vptJiUl0Q2am5uXLFni4OBgZWX1hz/8YdOmTYSQESNG/PDDD1p35MKFC5MnT3Z1daV1Dhs2LDg4+B//+Adde/z4cYlEsm3bNg013Lt3b/Xq1f7+/lZWVqampra2thMmTFi8ePG//vUvuoFBDsuxY8cCAgIsLS3Nzc1NTEzIb5MHPf300/Hx8XV1dVqPDIcMjScP8VTtEDREzu1+Yliec6oNNTk5OXPnzsVRAlUMw2RnZ//ub/5FRkaS3+50whAxRM7tfsJQLQAAAA8InEPLjz/+qOEVLj3l0YUh4tSpU3Fxcarp21599VXVDcLDwyUSiamp6RNPPPH9998bpJNa8/EdPHgwMDBQIpF4eHgsWrTo4cOHBq85MTHR19fXwsJCLBb7+vpu3LiRvgKntd1jx44lJiY+LhnRHyeGHis2dkabVgwMiAyN+0C87nFu2rRpxowZ3DxN3t7eDg4OhJDCwkLVzYqKimbNmjXAHeVDc+K5rKwsQkhiYmJjY2NJSYlUKh0/frxCoTBszREREcnJydXV1c3NzTk5OQKBQHVeMM3tpqamhoaGNjQ06NIQO2TO7X5CSNACgRN60vePS1tbW1BQkMGr0j1wbt++3cfHh5slkWVZb2/vAwcOmJiYuLm5NTY2cuUGD5wRERGqEx3Tm3n37t2ji2FhYcOHD6dPXLMsu3PnTkLI+fPnDVvz7NmzVY8tvfdcVVWlS7ssy8bExAQFBekYpBE4dYGhWgCjs2fPnurqamOr6lFu3ry5cePGLVu20Jk3OMHBwbGxsffv31+9erVeO8CL5sRzFRUVrq6u3MxzNI3r3bt3DVvz4cOHVY+tm5sbIYQbj9WaSm/z5s2lpaXcLJXQfwicAHrBPjp1WkxMjLm5+bBhw+ji22+/LRaLGYahk0/FxsauWrXq1q1bDMPIZLK0tDSRSOTs7PzWW2+5urqKRKLg4GBuXl9eVRGNWeH6LC0tjWXZmTNn9ly1bds2Hx+fTz/99NSpU3yPkuYEc4QQpVK5adMmd3d3CwuLgIAAOjjEl1riOalUqvp3Br0NKZVKjarm8vJyW1tbDw8PXdolhNjZ2YWGhqamprJ4O2CgGPaC1/hhqBZ6IjoMZ2lOnbZgwQIXFxdu46SkJEJITU0NXXzppZe8vb25tdHR0WKx+Pr16x0dHWVlZfQBE24sjldVGrLC9aTjUK1UKvXz81Mr9Pb2vnPnDsuy33zzjYmJiaenZ0tLC9tjqLbPCeZYll29erVQKMzLy2toaFi3bp2Jicnly5d12S9Oz8RzxcXFAoEgLS1NLpdfu3ZtzJgxU6dO5VWn/mru7OysrKxMT08XCoX79u3TsV0qLi6O6JYfSZdzGxAStEDghJ60/rhoTZ3GN3CqpkK7fPkyIWTLli19qIoXXQJnS0sLwzAzZsxQK+cCJ8uyq1atIoS888477L8Hzv4kmGtvb7e0tOQ+29bWJhQKly1bxmsHe008t2HDBu66YsSIERUVFbzq1F/NLi4uhBAHB4ePP/6Y++tBl3ZZlv3ss88IIV988YXWVhA4dYGhWoCBxzd1Gi8TJ060tLTkhjQNq7q6mmVZOtnTo2zbtm306NEZGRnnz59XLe9PgrkbN260tbWNHTuWrrKwsBg2bBivY9Jr4rn169fv3r379OnTLS0tt2/fDg4ODgoKqqio0L1a/dVcUVFRXV198ODBzz//fMKECT1vXWtIpUe/oF9++YXXjsCjIHACDLx+pk7TSigU1tTUDEhV/dTR0UEIEQqFGrYRiUR79+5lGOaNN95Qnf2/P0eptbWVELJhwwbuLeS7d+9qzQXLycrK+vDDD4uLiz09PbnCBw8eJCYmvvnmm88995xYLPby8srMzKyqqqIX8QavWSAQODk5hYeHZ2VllZWVJSQkaG2XY2FhQX77sqD/EDgBBl7/U6dpoFAoBqqq/qO/yFpfsQ8KClq5cmV5efnWrVu5wv4cJZpuNiUlRXUA7cKFC7r0OT09ff/+/WfOnFFL11peXq5UKlULra2t7e3ty8rKdKlWrzWrkslkpqamqp99VLuczs5O8tuXBf2HwAkw8LSmTjMzM6NDjn1QXFzMsuykSZP6X1X/OTs7MwzT1NSkdcutW7f6+vqWlJRwJf1JMDdy5EiRSFRaWsqrt6zGxHM0YD948IAraW5urq+vp6+OGKrmurq6+fPnq5bQMEw/q7ldDv2C6F1S6D8EToCBpzV1mkwmq6+vLygoUCgUNTU1au/z2dvbV1VV/fzzz83NzTQodnd3NzQ0dHV1XblyJTY21t3dfeHChX2oSnNWuD6wtLSUSqWVlZVat6QDtqpvHPYnwZxIJFq0aNGhQ4d27doll8uVSmVlZSWNTFFRUS4uLr1O6ac58ZyXl1dYWFhmZua5c+fa29srKipoTxYvXkw/bpCaxWLxyZMnz5w5I5fLFQpFSUnJ66+/LhaLV65cqbVdDv2C/P39tR5Y0AUCJ4BevP/++wkJCfHx8Y6OjqGhoZ6ensXFxWKxmK5dtmxZWFjYvHnzRo8evXXrVjqGxj0tsnTpUmdnZz8/v+nTp9fX1xNCOjo6/P39LSwsQkJCfHx8zp49y91W5FvVgIuIiCgrK+NuXh45ckQmk926dSswMHD58uWqW06aNIn+3OtylHbt2pWSkkIICQgIuH37dmZmJn06d9q0aeXl5YSQ1NTUFStWJCYmOjg4uLq6xsbGNjQ0EEI6Ozurq6uPHj3as6usxhcZGYbJzc2NiopavHixnZ2dn5/fvXv38vPzQ0JC6AYGqVkkEk2ePHnJkiVubm4SiSQyMtLT0/PixYv0wSjN7XIuX77s5uYWEBCgy8ag3WA/xvu4weso0BMZ3Ef2o6Oj7e3tB605jo7vcZaXl5uZmT3qzcLBp1QqQ0JC9uzZg5qp2tpakUiUnJysy8aDfG4/pnDFCfAYMOYEFzKZLD4+Pj4+Xi0ZiEEolcqCgoLm5uYBT/XzONZMbd68efz48TExMfqofGhC4ASA/oqLi4uMjIyKitLlKSG9Ki4uzs/PLyoq0vxq6RCpmRCyY8eO0tLS48ePCwSCAa98yELgBDBq69at27t3b1NTk5eXV15enqG780gffPBBTEzM9u3bDduNKVOmHDhwgJu8d4jXfPTo0V9//bW4uNjOzm7AKx/KzAzdAQDQJCEhQe1Vd6MVHh4eHh5u6F7A/5k1a9asWbMM3YvfIVxxAgAA8IDACQAAwAMCJwAAAA8InAAAADzg4SCd5OTkGLoLYFx0nE/8sUbnacPJD6CGYXWbsWnIysnJmTt3rqF7AQAwSLKzs+fMmWPoXhg1BE4AY0R/uXC1B2CEcI8TAACABwROAAAAHhA4AQAAeEDgBAAA4AGBEwAAgAcETgAAAB4QOAEAAHhA4AQAAOABgRMAAIAHBE4AAAAeEDgBAAB4QOAEAADgAYETAACABwROAAAAHhA4AQAAeEDgBAAA4AGBEwAAgAcETgAAAB4QOAEAAHhA4AQAAOABgRMAAIAHBE4AAAAeEDgBAAB4QOAEAADgAYETAACABwROAAAAHhA4AQAAeEDgBAAA4AGBEwAAgAcETgAAAB4QOAEAAHhA4AQAAOABgRMAAIAHhmVZQ/cBAMiBAwf27NnT3d1NF+/cuUMI8fLyoosmJiaLFy9esGCBwfoHAL9B4AQwCleuXBk3bpyGDX744YeAgIBB6w8APAoCJ4Cx8PX1vXHjRq+rZDJZeXn5IPcHAHqFe5wAxuLVV18VCAQ9ywUCwaJFiwa/PwDQK1xxAhiL27dvy2SyXv9LlpeXy2Sywe8SAPSEK04AYyGVSp988kmGYVQLGYaZOHEioiaA8UDgBDAir732mqmpqWqJqanpa6+9Zqj+AEBPGKoFMCLV1dWurq7cSymEEBMTk6qqKhcXFwP2CgBU4YoTwIg4OzuHhoZyF52mpqbPPvssoiaAUUHgBDAur776quo40KuvvmrAzgBATxiqBTAucrncycmps7OTECIQCKqrq21tbQ3dKQD4P7jiBDAu1tbW06ZNMzMzMzMzmz59OqImgLFB4AQwOq+88opSqVQqlZicFsAIYagWwOh0dHQ4OjqyLFtbW2thYWHo7gDAv2NVZGdnG7o7AAAAxiU7O1s1Vpr1usXgdwsAVJWWljIMozlfilGZO3dubGxsUFCQoTuiXykpKYSQFStWGLojMHjmzp2rVtJL4JwzZ86gdAYAHulPf/oTIcTMrJf/ocZp7ty5QUFBv/tfj9zcXIIfySFGp8AJAAb3GIVMgKEGT9UCAADwgMAJAADAAwInAAAADwicAAAAPCBwAoDBHD9+3MbG5ssvvzR0R/Tl1KlTcXFx+fn5UqmUYRiGYdRm7Q8PD5dIJKampk888cT3339vkE7Gx8f7+flZW1sLhUKZTLZmzZqWlhbVDQ4ePBgYGCiRSDw8PBYtWvTw4UOD15yYmOjr62thYSEWi319fTdu3CiXy3Vp99ixY4mJiUqlUseGetdzAgQWAIAn0uMlcV0UFhZaW1sfO3ZMH13Sh5dffvnll1/WceNNmzbNmDFDLpfTRW9vbwcHB0JIYWGh6mZFRUWzZs0a4I7yERoampGRUVdXJ5fLs7OzBQLBtGnTuLVZWVk0UDU2NpaUlEil0vHjxysUCsPWHBERkZycXF1d3dzcnJOTIxAInn/+eR3bTU1NDQ0NbWho0KUhtrdzG4ETAAZA3wLnoGlrawsKCup/PboHzu3bt/v4+LS3t3Ml3t7eBw4cMDExcXNza2xs5MoNHjgjIiK6urq4RfqW6r179+hiWFjY8OHDu7u76eLOnTsJIefPnzdszbNnz1Y9tpGRkYSQqqoqXdplWTYmJiYoKEjHIN3z3MZQLQD8/u3Zs6e6unrQmrt58+bGjRu3bNkiEolUy4ODg2NjY+/fv7969epB64xWhYWFXO50QoijoyMhpK2tjS5WVFS4uroyDEMXR44cSQi5e/euYWs+fPiw6rF1c3MjhHDjsZrbJYRs3ry5tLQ0NTVVl7Z6QuAEAMM4f/68u7s7wzD0UmPXrl1isdjS0vLo0aMvvPCCtbX1iBEjDh06RDdOS0sTiUTOzs5vvfWWq6urSCQKDg6+dOkSXRsTE2Nubj5s2DC6+Pbbb4vFYoZhamtrCSGxsbGrVq26desWwzAymYwQ8vXXX1tbW3/wwQd62rW0tDSWZWfOnNlz1bZt23x8fD799NNTp071+lmWZXfs2DFmzBihUGhnZ/fiiy/++OOPdJXmQ0QIUSqVmzZtcnd3t7CwCAgI6Nv8qffv37ewsPDy8qKLUqlU9W8OehtSKpUaVc3l5eW2trYeHh66tEsIsbOzCw0NTU1NZfuW5kT18hNDtQDQN6RPQ7UVFRWEkPT0dLq4fv16Qsjp06ebmpqqq6tDQkLEYnFnZyddGx0dLRaLr1+/3tHRUVZWRh8q4cbfFixY4OLiwtWclJRECKmpqaGLL730kre3N7e2sLBQIpHEx8fz7bCOQ7VSqdTPz0+t0Nvb+86dOyzLfvPNNyYmJp6eni0tLWyPodpNmzaZm5vv27evsbHxypUrTz75pKOj48OHD+lazYdo9erVQqEwLy+voaFh3bp1JiYmly9f5rWDra2tEokkJiaGKykuLhYIBGlpaXK5/Nq1a2PGjJk6dSqvOvVXc2dnZ2VlZXp6ulAo3Ldvn47tUnFxcYSQkpISra30PLcROAFgAAxg4OTuXWVkZBBCbt68SRejo6NtbGy4z16+fJkQsmXLFrrIK3D2mS6Bs6WlhWGYGTNmqJVzgZNl2VWrVhFC3nnnHfbfA2dbW5uVlVVUVBT3qW+//ZYQwsV4DYeovb3d0tKS+2xbW5tQKFy2bBmvHVy/fr2Pjw/3QBO1YcMG7lprxIgRFRUVvOrUX80uLi6EEAcHh48//pj760GXdlmW/eyzzwghX3zxhdZWep7bGKoFACNlbm5OCFEoFL2unThxoqWlJTeMaTyqq6tZlrW0tNSwzbZt20aPHp2RkXH+/HnV8rKyspaWlokTJ3IlgYGB5ubm3KC0GtVDdOPGjba2trFjx9JVFhYWw4YN43V8Dh8+nJOTc+LECYlEwhWuX79+9+7dp0+fbmlpuX37dnBwcFBQEP2Lx+A1V1RUVFdXHzx48PPPP58wYULP29i9tkvRL+iXX37htSMUAicAPK6EQmFNTY2he6Guo6ODECIUCjVsIxKJ9u7dyzDMG2+80d7ezpU3NjYSQqysrFQ3trW1bW5u1tpua2srIWTDhg3Mb+7evav6RIxmWVlZH374YXFxsaenJ1f44MGDxMTEN99887nnnhOLxV5eXpmZmVVVVfSC3uA1CwQCJyen8PDwrKyssrKyhIQEre1yaIp4+mXxhcAJAI8lhULR2Ng4YsQIQ3dEHf1F1vqKfVBQ0MqVK8vLy7du3coV2traEkLUwqSOu+nk5EQISUlJUR1UvHDhgi59Tk9P379//5kzZ4YPH65aXl5erlQqVQutra3t7e3Lysp0qVavNauSyWSmpqaqn31Uu5zOzk7y25fFFwInADyWiouLWZadNGkSXTQzM3vUoO4gc3Z2ZhimqalJ65Zbt2719fUtKSnhSsaOHWtlZfXdd99xJZcuXers7Hzqqae01jZy5EiRSFRaWsqrtyzLrl279urVqwUFBWpXuoQQGrAfPHjAlTQ3N9fX19NXRwxVc11d3fz581VLaBimn9XcLod+QfQuKV8InADw2Oju7m5oaOjq6rpy5UpsbKy7u/vChQvpKplMVl9fX1BQoFAoampq1F4HtLe3r6qq+vnnn5ubmxUKRVFRkf5eR7G0tJRKpZWVlVq3pAO2qm8cikSiVatWHT58eP/+/XK5/OrVq0uXLnV1dY2OjtaltkWLFh06dGjXrl1yuVypVFZWVtLIFBUV5eLi0uuUftevX//oo48yMzMFAgGjIjk5mRDi5eUVFhaWmZl57ty59vb2iooK2pPFixfTjxukZrFYfPLkyTNnzsjlcoVCUVJS8vrrr4vF4pUrV2ptl0O/IH9/f60HticETgAwjJ07dwYGBhJC1q5dO2vWrF27dqWkpBBCAgICbt++nZmZSR89nTZtWnl5Of1IR0eHv7+/hYVFSEiIj4/P2bNnuVuJy5YtCwsLmzdv3ujRo7du3UqH4LiHTZYuXers7Ozn5zd9+vT6+np971pERERZWRl38/LIkSMymezWrVuBgYHLly9X3XLSpEn0557z/vvvJyQkxMfHOzo6hoaGenp6FhcXi8ViQojWQ5SamrpixYrExEQHBwdXV9fY2NiGhgZCSGdnZ3V19dGjR3t2ldX4IiPDMLm5uVFRUYsXL7azs/Pz87t3715+fn5ISAjdwCA1i0SiyZMnL1myxM3NTSKRREZGenp6Xrx4kT4YpbldzuXLl93c3AICAnTZWJ3qaDheRwGAviH6n3IvOjra3t5er01opeN7nOXl5WZmZo96s3DwKZXKkJCQPXv2oGaqtrZWJBIlJyfrsnHPcxtXnADw2OhvUovBIpPJ4uPj4+Pj1ZKBGIRSqSwoKGhubo6KikLN1ObNm8ePHx8TE9O3j/MOnIGBgaampuPHj+9be5otWrRIJBIxDNO3R4SNTXJyMn1M4K9//SstGdgkSoOckqm7uzslJSU4OFj3j6hmU6LMzMwcHR3/+Mc/Hj58eKA6pvm0MfKMTr+zkwQ4cXFxkZGRUVFRujwlpFfFxcX5+flFRUWaXy0dIjUTQnbs2FFaWnr8+HGBQNDHKlQvP3Ucqp0yZcq4ceN4XRfrTm1ejMcdvfHwySef0MWBTaI0mCmZfvrpp8mTJxNC+vDVe3t7cxO+1NfXnzp1ytfXlxCSlZU1UN3TetoYbUYn9vdykhA9D9XGxcXRl/09PT1zc3P115BmvNKKsSx74sSJtWvX6q8/wFdBQUFCQoJq7hStep7bfRyq5eaz1117ezuvi5XfpYiIiKamphkzZvTt42rHsJ+16e6HH37485//vHTp0v6PNNjZ2U2ZMuXjjz8mhOTk5GjdfgBPm7S0NBMTk+joaINfAWj2mJ4k+paQkPDrr7+yLHvnzp2XX37Z0N3RVXh4+IcffmjoXsD/mTVrVlxcnOqTzH3Qx8DZhytcXml9+hCYh4JBTo3EGTduXH5+/oIFCzRPhqI7OpEHnSRFswE8bYwzo9OAM9RJAjB09DFw3rx509fXVywW0+fCVadb/Oc//+nn52djYyMSifz9/U+cOEF6S+tDCNm3b9/EiRNFIpFYLPb09OSmzzAxMfnqq69eeOEFGxsbV1dXOhWvVloT7rCPTtbz0UcfWVpaSiSS6urqVatWubm5LV26VCwWm5iYPPXUUy4uLgKBQCwWP/nkkyEhIfQtY1tb2zVr1mjeazVqSZRu3rzJ9PDf//3fOh5Dtdo076DWg9MffcjQdOXKFUJIaGgoVzI4p01/MjrhJAGA/0913Fb3e5xSqfTOnTsKheLatWvPPPOMSCT66aef6Nrc3NzNmzfX19fX1dVNmjTJwcGBlqtlJ6BvI23fvr2urq6+vv5vf/vbggULWJWkOY2NjfX19dOnTxcKha2trbqMRGtOuKNLsp533303PT39T3/60//+7/++//77hJBLly61trbW1tZOmzaNEPLVV1/V1NS0trbSx7FKS0s177Xa7SvVXBDl5eV//vOf6a49ePDAzs4uODhYqVTqfgzVMkv0JxuRjp555pme9zi1ZmhSvcfZ1tZWVFTk4eERHh5OcyppPoADddoMYEYnnCS9Ivp/HcUY8L3HCb8DPc/tAXg4iF49rF69uueWdMpdmitA9f9zZ2enra1tWFgYt2VXVxfNKar2lMcXX3xBCLl27Zouu6ch4Q7fZD0sy9LfxObmZrr4+eefE0KuXr2q+vFeH29R3WsNv4mqZs+eLRKJfvzxR821afhN7E82It31Gji18vb2Vvtzzd/f//PPP6e3rHrSx2mjj4xOLE4SFQic8HvV89w269t1qtqPoI2NDQ2fauit0J6vXl25cqWxsXHq1Klciamp6bvvvvuoGvo2BaVqwh2+yXoeVVtXV5fWjj1qrx8lJyfnyJEjiYmJo0eP7nNt/clGNAhsbGzoHc2urq5ffvnl5MmTMTExCZ9FO3wAACAASURBVAkJ58+fd3R0VNtY36fNtm3bCgsLMzIy5s6dq1qOk0QN35NEx/nEH2t0njZdnmuD37EBCJyEEIFAwP3v+uqrr5KSksrKyugsgr1uL5fLyW95AAZHf5L16EKXve5VXV3d8uXLAwMD6WVQn2vT9w4OFDMzMzc3t0WLFimVyv/6r//avn37X/7yFzK4pw2dIPQPf/jDG2+8kZiYyJXjJOmn1NTU1NTUAanKyKn9yQVDzQDMHNTV1VVfX+/u7k4IuXfv3uzZs4cNG3bp0qWmpibVXyVVNM9LbW1t/1vXUX+S9Wil41736t13321sbFSd6Llvtel1B/WBzq18/fp1YojTZsAzOmk1FE4SDNXC71LPU30AAufZs2e7u7uffPJJQsjVq1cVCsWyZcukUimdzKXXj3h6etrb2588ebL/reuoP8l6tNJxr3v66quvDhw4sHHjxieeeIKWvPfee32rTa87qA//8z//QwihA48GOW0GNqOTVjhJAH43+hg4Ozs7m5qaurq6vv/++5iYGA8PD5rch153njp1qqOjo7y8XPXeiWpaHxMTk3Xr1p07dy4mJub+/fvd3d3Nzc304kNP+pOsRysNe62BXC5/6623xo8f/+c//5kQ0tHR8d1335WWlup4DNVG5/S6g5rpmKGpvb29u7ubZdmqqqq9e/du2LDB0dFxxYoVxECnzcBmdNJqiJ8kAL8rqhekOj5Vu3fv3rCwMGdnZzMzMwcHh3nz5t29e5dbu3btWnt7e1tb28jISPr2mLe39717977//nsPDw8LC4s//OEP9PH3nTt3+vv7i0QikUg0YcKEjIyMxMREmgxo1KhRt27d2r9/v52dHSFkxIgRWh+szcjIoLMa0s/u3r3b2tqaEOLh4UFflenu7k5KSho1apRAILCzs5s9e/aNGzfoZ7l2R44cSRMapKam0to8PT3/+c9/fvjhhzY2NoQQFxeXAwcOZGVl0fSndnZ2hw4detRex8bG0s3EYvGf/vSn9PT0YcOGEUIsLS1nzpyplhyOmj59uo7HcMOGDaq1ad5BrQdHswsXLkyePNnV1ZV2ctiwYcHBwf/4xz/o2uPHj0skkm3btvX84OHDh3s+UisUCkeNGrVs2bJ79+4NwmnD9cHR0ZE+SavqvffeU30dBSdJn08SgqFa+J3qeW4zrMoAbk5Ozty5c1ndkpkBAHAYhsnOzp4zZ46hO6JfkZGRhJDc3FxDdwQGT89zG2nFAAAAeHhsAuePP/7Yc+4xjp5ytg0FOLAAALw8NoHT19dXwxh0VlaWoTv4uMKBBdCfU6dOxcXFGXlS2Pj4eD8/P2tra6FQKJPJ1qxZo5Z/++DBg4GBgRKJxMPDY9GiRQ8fPjR4zYmJib6+vhYWFmKx2NfXd+PGjfQ9b63tHjt2LDExsb8Z0VV/JXV8OAgAQA3Bw0E9bNq0acaMGXK5nC4abVLY0NDQjIyMuro6uVyenZ0tEAimTZvGraV/PScmJjY2NpaUlEil0vHjxysUCsPWHBERkZycXF1d3dzcnJOTIxAInn/+eR3bTU1NDQ0NbWho0KUhdqDmqgUAUKPvwNnW1hYUFGTwqnQPnNu3b/fx8VGd2djb2/vAgQMmJiZubm6NjY1cucEDZ0REhGpiZ/oUDPfQe1hY2PDhw+m7ZCzL0ke4z58/b9iaZ8+erXps6UNbVVVVurTLsmxMTExQUJCOQbrnuf3YDNUCwFA2gHlGByFl6c2bNzdu3LhlyxaRSKRabpxJYQsLC1VfaKbTR7e1tdHFiooKV1dXbpKNkSNHEkLu3r1r2JoPHz6semzd3NwIIdx4rOZ2CSGbN28uLS3t8wyRCJwAMEjYR2cDjYmJMTc3p2+dEkLefvttsVjMMAydYVEtz2haWppIJHJ2dn7rrbdcXV1FIlFwcDA3CwSvqkifEspqlZaWxrLszJkze67qT1JYrTlTlUrlpk2b3N3dLSwsAgIC6CAiX/fv37ewsPDy8qKLUqlU9e8MehtSKpUaVc3l5eW2trYeHh66tEsIsbOzCw0NpbmV+tAchmoBYAAQHYZqNWcDXbBggYuLC7dxUlISIaSmpoYuqqVLi46OFovF169f7+joKCsrow+YcGNxvKrSmlBWlY5DtVKp1M/PT61wAJPCPipn6urVq4VCYV5eXkNDw7p160xMTC5fvqzLfnFaW1slEklMTAxXUlxcLBAI0tLS5HL5tWvXxowZM3XqVF516q/mzs7OysrK9PR0oVBIpyXRpV0qLi6OEFJSUqK1lZ7nNgInAAwArYFTazZQvoGTy47Osuzly5cJIVu2bOlDVbzoEjhbWloYhpkxY4ZauT6SwqrmTG1vb7e0tOQ+29bWJhQKly1bxmsH169f7+Pjwz3QRG3YsIG71hoxYkRFRQWvOvVXM511y8HB4eOPP35UxvVe22VZ9rPPPiOEfPHFF1pb6XluY6gWAAZD/9OdajBx4kRLS0tuSNOwaEZxOn/ho2zbtm306NEZGRnnz59XLe9PztQbN260tbWNHTuWrrKwsBg2bBivY3L48OGcnJwTJ05IJBKucP369bt37z59+nRLS8vt27eDg4ODgoJognSD11xRUVFdXX3w4MHPP/98woQJPW9d99ouRb+gX375hdeOUAicADAY9J0NVCgU1tTUDEhV/dTR0UEIEQqFGrahOQYYhnnjjTfa29u58v4cpdbWVkLIhg0buAlM7t69q/pEjGZZWVkffvhhcXGxp6cnV/jgwYPExMQ333zzueeeE4vFXl5emZmZVVVV9CLe4DULBAInJ6fw8PCsrKyysrKEhASt7XLo1NP0y+ILgRMABoNes4EqFArjyT5Lf5G1vmI/4ElhnZycCCEpKSmqg4oXLlzQpc/p6en79+8/c+YMzXrLKS8vVyqVqoXW1tb29vZlZWW6VKvXmlXJZDJTU1PVzz6qXU5nZyf57cviC4ETAAaD1mygZmZmannQdFdcXMyy7KRJk/pfVf85OzszDNPU1KR1y4FNCjty5EiRSFRaWsqrtyzLrl279urVqwUFBWpXuoQQGrAfPHjAlTQ3N9fX19NXRwxVc11d3fz581VLaBimn9XcLod+QfQuKV8InAAwGLRmA5XJZPX19QUFBQqFoqamRu19vp55Rru7uxsaGrq6uq5cuRIbG+vu7k6zAvOtSseEsrqztLSUSqWVlZVatxzYpLAikWjRokWHDh3atWuXXC5XKpWVlZU0MkVFRbm4uPQ6pd/169c/+uijzMxMgUCgOk81TWnn5eUVFhaWmZl57ty59vb2iooK2pPFixfTjxukZrFYfPLkyTNnzsjlcoVCUVJS8vrrr4vF4pUrV2ptl0O/IH9/f60HticETgAYJO+//35CQkJ8fLyjo2NoaKinp2dxcbFYLKZrly1bFhYWNm/evNGjR2/dupWOoXFPiyxdutTZ2dnPz2/69On19fWEkI6ODn9/fwsLi5CQEB8fn7Nnz3K3FflWNeAiIiLKysq4m5dHjhyRyWS3bt0KDAxcvny56paTJk2iP/e6HKVdu3alpKQQQgICAm7fvp2ZmUmfzp02bVp5eTkhJDU1dcWKFYmJiQ4ODq6urrGxsQ0NDYSQzs7O6urqo0eP9uwqq/FFRoZhcnNzo6KiFi9ebGdn5+fnd+/evfz8/JCQELqBQWoWiUSTJ09esmSJm5ubRCKJjIz09PS8ePEifTBKc7ucy5cvu7m5BQQE6LKxOtXRcLyOAgB9QwZ3rtro6Gh7e/tBa46j43uc5eXlZmZmj3qzcPAplcqQkJA9e/agZqq2tlYkEiUnJ+uycc9zG1ecAPBY6m+CC32SyWTx8fHx8fFqyUAMQqlUFhQUNDc3D3iWwMexZmrz5s3jx4+PiYnp28cROAEABl5cXFxkZGRUVJQuTwnpVXFxcX5+flFRkeZXS4dIzYSQHTt2lJaWHj9+XCAQ9K0GBE4AeMysW7du7969TU1NXl5eeXl5hu7OI33wwQcxMTHbt283bDemTJly4MABbvLeIV7z0aNHf/311+LiYjs7uz5XYjaAHQIAGAQJCQlqr7obrfDw8PDwcEP3Av7PrFmzZs2a1c9KcMUJAADAAwInAAAADwicAAAAPCBwAgAA8NDLw0GRkZGD3w8AeNylpKTk5uYauhf6dfHiRYIfySGPYVVmJ7pw4cKOHTsM2BsAoOjE3xMmTDB0RwCArFy5MigoiFv8t8AJAEZizpw5hJCcnBxDdwQA1OEeJwAAAA8InAAAADwgcAIAAPCAwAkAAMADAicAAAAPCJwAAAA8IHACAADwgMAJAADAAwInAAAADwicAAAAPCBwAgAA8IDACQAAwAMCJwAAAA8InAAAADwgcAIAAPCAwAkAAMADAicAAAAPCJwAAAA8IHACAADwgMAJAADAAwInAAAADwicAAAAPCBwAgAA8IDACQAAwAMCJwAAAA8InAAAADwgcAIAAPCAwAkAAMADAicAAAAPCJwAAAA8IHACAADwgMAJAADAg5mhOwAAhBDS1tb266+/coudnZ2EkIaGBq5EKBRaWloaoGcA8O8YlmUN3QcAILt27Xr77bc1bJCRkbFs2bJB6w8APAoCJ4BRqKmpcXV1VSqVva41NTV98OCBk5PTIPcKAHrCPU4Ao+Dk5DRlyhRTU9Oeq0xNTf/4xz8iagIYCQROAGPxyiuv9DoCxLLsK6+8Mvj9AYBeYagWwFg0Nzc7OTmpPiJEmZub19TUWFtbG6RXAKAGV5wAxkIikcyYMUMgEKgWmpmZzZo1C1ETwHggcAIYkQULFnR1damWKJXKBQsWGKo/ANAThmoBjEhnZ6ejo2NzczNXYmVlVVtbKxQKDdgrAFCFK04AI2Jubh4ZGWlubk4XBQLB3LlzETUBjAoCJ4BxmT9/Pp02iBCiUCjmz59v2P4AgBoM1QIYl+7u7mHDhtXU1BBCHB0dHz582OvLnQBgKLjiBDAuJiYm8+fPNzc3FwgECxYsQNQEMDYInABGZ968eZ2dnRinBTBORpcdJScnx9BdADAwlmUdHBwIIXfu3Pn5558N3R0AA5szZ46hu/BvjO4eJ8Mwhu4CAAAYEWOLU0Z3xUkIyc7ONra/LwAG2fXr1wkhfn5+umyck5Mzd+5cY/tx0QeGYfD7MKTQc9vQvVBnjIETAHQMmQAw+PBwEAAAAA8InAAAADwgcAIAAPCAwAkAAMADAicAAAAPCJwAQ9Tx48dtbGy+/PJLQ3dEX06dOhUXF5efny+VShmGYRjm1VdfVd0gPDxcIpGYmpo+8cQT33//vUE6GR8f7+fnZ21tLRQKZTLZmjVrWlpaVDc4ePBgYGCgRCLx8PBYtGjRw4cPDV5zYmKir6+vhYWFWCz29fXduHGjXC7Xpd1jx44lJiYqlUodGzJerJEhhGRnZxu6FwCPk+zs7D78Xy4sLLS2tj527Jg+uqQnuv8+bNq0acaMGXK5nC56e3vTyZgKCwtVNysqKpo1a9bAd1RnoaGhGRkZdXV1crk8OztbIBBMmzaNW5uVlUUISUxMbGxsLCkpkUql48ePVygUhq05IiIiOTm5urq6ubk5JydHIBA8//zzOrabmpoaGhra0NCgS0NsX89tfTO+DiFwAvBknD8unLa2tqCgoAGpSsffh+3bt/v4+LS3t3Ml3t7eBw4cMDExcXNza2xs5MoNHjgjIiK6urq4RTq3w7179+hiWFjY8OHDu7u76eLOnTsJIefPnzdszbNnz1Y9tpGRkYSQqqoqXdplWTYmJiYoKEjHIG2c5zaGagFAv/bs2VNdXT1ozd28eXPjxo1btmwRiUSq5cHBwbGxsffv31+9evWgdUarwsJC1QQ4jo6OhJC2tja6WFFR4erqyk1EOnLkSELI3bt3DVvz4cOHVY+tm5sbIYQbj9XcLiFk8+bNpaWlqampurRlnBA4AYai8+fPu7u7MwxDLzV27dolFostLS2PHj36wgsvWFtbjxgx4tChQ3TjtLQ0kUjk7Oz81ltvubq6ikSi4ODgS5cu0bUxMTHm5ubDhg2ji2+//bZYLGYYpra2lhASGxu7atWqW7duMQwjk8kIIV9//bW1tfUHH3ygp11LS0tjWXbmzJk9V23bts3Hx+fTTz89depUr59lWXbHjh1jxowRCoV2dnYvvvjijz/+SFdpPkSEEKVSuWnTJnd3dwsLi4CAAHqpxNf9+/ctLCy8vLzoolQqVf2bg96GlEqlRlVzeXm5ra2th4eHLu0SQuzs7EJDQ1NTU9nHd5JIA1/x9kAwVAvAU9+GsyoqKggh6enpdHH9+vWEkNOnTzc1NVVXV4eEhIjF4s7OTro2OjpaLBZfv369o6OjrKyMPlTCjb8tWLDAxcWFqzkpKYkQUlNTQxdfeuklb29vbm1hYaFEIomPj+/Dnury+yCVSv38/NQKvb2979y5w7LsN998Y2Ji4unp2dLSwvYYqt20aZO5ufm+ffsaGxuvXLny5JNP0lzidK3mQ7R69WqhUJiXl9fQ0LBu3ToTE5PLly/z2rvW1laJRBITE8OVFBcXCwSCtLQ0uVx+7dq1MWPGTJ06lVed+qu5s7OzsrIyPT1dKBTu27dPx3apuLg4QkhJSYnWVoxzqNb4OoTACcDTAAZO7t5VRkYGIeTmzZt0MTo62sbGhvvs5cuXCSFbtmyhi7wCZ39o/X1oaWlhGGbGjBlq5VzgZFl21apVhJB33nmH/ffA2dbWZmVlFRUVxX3q22+/JYRwMV7DIWpvb7e0tOQ+29bWJhQKly1bxmvv1q9f7+Pjwz3QRG3YsIG7zhkxYkRFRQWvOvVXs4uLCyHEwcHh448/5v560KVdlmU/++wzQsgXX3yhtRXjDJwYqgWAXpibmxNCFApFr2snTpxoaWnJDWMaj+rqapZlLS0tNWyzbdu20aNHZ2RknD9/XrW8rKyspaVl4sSJXElgYKC5uTk3KK1G9RDduHGjra1t7NixdJWFhcWwYcN4HZ/Dhw/n5OScOHFCIpFwhevXr9+9e/fp06dbWlpu374dHBwcFBRE/+IxeM0VFRXV1dUHDx78/PPPJ0yY0PM2dq/tUvQL+uWXX3jtiPFA4ASAvhAKhTU1NYbuhbqOjg5CiFAo1LCNSCTau3cvwzBvvPFGe3s7V97Y2EgIsbKyUt3Y1ta2ublZa7utra2EkA0bNjC/uXv3ruoTMZplZWV9+OGHxcXFnp6eXOGDBw8SExPffPPN5557TiwWe3l5ZWZmVlVV0Qt6g9csEAicnJzCw8OzsrLKysoSEhK0tsuxsLAgv31ZjyMETgDgTaFQNDY2jhgxwtAdUUd/kbW+Yh8UFLRy5cry8vKtW7dyhba2toQQtTCp4246OTkRQlJSUlQH9C5cuKBLn9PT0/fv33/mzJnhw4erlpeXlyuVStVCa2tre3v7srIyXarVa82qZDKZqamp6mcf1S6ns7OT/PZlPY4QOAGAt+LiYpZlJ02aRBfNzMweNag7yJydnRmGaWpq0rrl1q1bfX19S0pKuJKxY8daWVl99913XMmlS5c6OzufeuoprbWNHDlSJBKVlpby6i3LsmvXrr169WpBQYHalS4hhAbsBw8ecCXNzc319fX01RFD1VxXVzd//nzVEhqG6Wc1t8uhXxC9S/o4QuAEAJ10d3c3NDR0dXVduXIlNjbW3d194cKFdJVMJquvry8oKFAoFDU1NWqvA9rb21dVVf3888/Nzc0KhaKoqEh/r6NYWlpKpdLKykqtW9IBW9U3DkUi0apVqw4fPrx//365XH716tWlS5e6urpGR0frUtuiRYsOHTq0a9cuuVyuVCorKytpZIqKinJxcel1Sr/r169/9NFHmZmZAoGAUZGcnEwI8fLyCgsLy8zMPHfuXHt7e0VFBe3J4sWL6ccNUrNYLD558uSZM2fkcrlCoSgpKXn99dfFYvHKlSu1tsuhX5C/v7/WA2ukDPBAkkYET9UC8NSHJw/T09Ppm5eWlpYzZ87MyMigz2uMGjXq1q1bu3fvtra2JoR4eHj89NNPLMtGR0cLBAI3NzczMzNra+sXX3zx1q1bXG11dXVhYWEikcjLy2v58uXvvfceIUQmk9H3Vb7//nsPDw8LC4s//OEPDx8+PH78uEQi2bZtWx/2VJffh5iYGIFA0NbWRhcPHz7s7e1NCHF0dKRP0qp67733VF9H6e7uTkpKGjVqlEAgsLOzmz179o0bN+gqrYfo119/Xbt2rbu7u5mZmZOT00svvVRWVsay7OzZswkhmzZt6tnVq1ev9vqznJSURDeora2NjY2VyWRCodDKymry5MlHjhzhPm6QmlmWnTlzppeXl5WVlVAo9Pb2joqKunr1qo7tUhEREW5ubty8RRoY51O1xtchBE4AngbhxyU6Otre3l6vTehCl9+H8vJyMzOzR71ZOPiUSmVISMiePXtQM1VbWysSiZKTk3XZ2DgDJ4ZqAUAnj0tSC5lMFh8fHx8fr5YMxCCUSmVBQUFzc3NUVBRqpjZv3jx+/PiYmBh9VD44EDiNSHJyMn204a9//SstGcDET1pzDHGWLFkikUgYhtHlSQfVnE0bN27sdZsdO3YwDGNiYuLr63vu3Lm+9V+1IYZh6LDhggUL/vd//7dvFaoy1JFX2ymGYczNzZ2dnZ999tmkpKSGhob+tz40xcXFRUZGRkVF6fKUkF4VFxfn5+cXFRVpfrV0iNRMCNmxY0dpaenx48cFAsGAVz54DH3Jq44M7aHa8vJyQsgnn3xCFwcw8ZPmXD9q6AycukyIRdF7SMOGDes5gUhXVxedxHLKlCl9771KQ3T+mpaWlmPHjrm7u1tZWf3444/9r9mAR57bKfr0zdmzZxcuXMgwjKurq45ztul7OCsuLo6+7O/p6Zmbm6u/hrTi9ftw4sSJtWvX6rU/wEtBQUFCQoJq7hStjHOo1vg6hMCp8vM9gLTm+lHVh8BJH9nPyclRW5WdnR0cHDzggZM6cuQIIeTtt9/uf80GPPJqO0Xl5uaamJg4Ozur5sB6FOP8cdGHIf77MAQZ57mNodrfLZZlc3Nzd+/eTRe15vpRxSUb0t2yZcsIIZ988ola+Y4dO+jUoPrw9NNPE0KuXbump/r7pj9HnvPyyy8vXLiwurqaGz0GACPx+AXO1NRUsVhsYmLy1FNPubi4CAQCsVj85JNPhoSE0HeQbW1t16xZw23/z3/+08/Pz8bGRiQS+fv7nzhxghDy97//3crKimEYOzu7goKC7777zsPDw9TUVO3F3l5pTrFENGYm0rpWFa/ET4QQpVKZkJAwevRoCwsLR0dHLy+vhIQEen3Tk1quH5Zlk5KSRo8eLRQKbWxs6OsEHF3yQD333HNjxow5e/bsjRs3uMJ//etfbW1t4eHhahsP1JfS1dVFVOZXexyPvAb0LcmioiKtWwLAoDLg1W6viA5DMe+//z4h5NKlS62trbW1tdOmTSOEfPXVVzU1Na2trfRhrdLSUrpxbm7u5s2b6+vr6+rqJk2a5ODgQMuvX79uaWn5+v9j784Dmrjz//G/J5CQcCOCIkcRIlAUUKtdQSn1Y8taWTyL4tVaV6VqRUCtIqDIVVELfFGyrsrSrlq5tGC9atWyFq/aKkhpawFFBY+AIiCHQJjfH/NrNssREpKQIM/HX2bmnde8ZxLyct4z8359+CHzMjQ09MCBAzJ2UnqJJemViaSv7TBgKFfhp9jYWC0trdzc3MbGxp9//nnIkCFvv/12l/3vXOsnLCyMoqjPP/+8pqamsbGRKfsgHqrtsQ4UU3ri//2//0cICQoKEi+fNWtWWloaM4eZ5FBtrz+UDqOaBw8eJIRs2LCh/x75zjslVldXRwixtrbuMpQkzRzOUgVZfh/gVaKZ323N65DMibO+vp55+eWXXxJCxE/gMpWA0tPTO7+RmYaYqZ9A0/Q///lPQsihQ4e++uqrkJAQ2TsppcSS9MpEPdYtkuXnu7vCT+PHj3/zzTfFkVesWMFisV6+fNm5/x1q/TQ2Nurq6r777rviBr24xnn37t3nz5/r6emZmJgwz56XlZVZWVm9fPmyc+KUJNeHInlzUHZ29pAhQ8zNzSsqKuj+eeQ77FRnFEUZGxt3uUqSZv64qAIS50Cjmd9tbdWcx/Yp5n4/ZtSOEMLc5dzlzJnMKvHjaCtWrPjuu+8+/vjjd955Jzs7u9cdkCyxJL0ykbx1i6TrUPipubmZy+WK14pEIjabLXl1jcHU+jl79qy41k9paWljY+OUKVN60QdJRkZGCxYs2L9/f3p6+kcffZSYmLhq1SoOh8NM6NwdeT+U2tpaiqK0tLSGDh06bdq0rVu3Wlpakv555KVraGigaZqZnkYWfn5+Mrbs1xITE7OystTdC+gjssye2Pf63zVOeZ08efLtt982MzPT0dGRvPbJiI2NffHiRedKcvISl1iSXplIkbpFPZo2bdrPP/+cm5vb1NT0008/5eTk/O1vf+vw891lrR/mq8mUd1AQc4vQ3r17nz9/npWV9fHHH3fZTJEPhTk5a2trq6io+Ne//sU860L655GX7o8//iCEODk5Kd5DAFCiV+GMU4r79+/PmjVr9uzZ//rXv4YNG7Z7927Jn+nW1ta1a9cyt33GxMQwI8C9IFliSXplIkXqFvUoMjLy559/XrJkyYsXLywsLObOndvhdp7du3d/++23Fy5c6JA/mLOlly9fKt6H0aNHT5gw4erVqwEBAX5+fiYmJp3bqOhD6Y9HXrozZ84QQt577z0Z2w+E8zCKooKDg7u78QpePZmZmfPmzVN3Lzp6xRNnUVFRa2vrqlWr7OzsSKenLNasWbN8+fLZs2dXVlZGR0d7e3u7u7v3YiuSJZakVyZSpG5Rj4qLi8vKyqqqqrS1O36sNE1v2rSppqYmJyen89pRo0axWKz//Oc/K1euVLwbq1atunr1anZ2NnPVsDMVfSj98chL8fjx48TEauEXIAAAIABJREFURCsrq6VLlyreQwBQold8qNbGxoYQcu7cuebm5pKSEskLWikpKZaWlrNnzyaExMXFOTs7L1y4kLmPURbdlViSXplIkbpFPfrkk09sbGy6nEhPeq0fppJDdnZ2ampqXV3drVu3xM8gMuSqAzV37tzBgwfPmjWLyYudqehD6Y9HXoym6RcvXjDFIqqqqjIyMiZOnKilpZWTkyP7NU4A6CNqvDGpS6Snu+aSkpKYGRRtbW1/+OGH7du3GxkZEUKGDBly+PDh9PR0pjiqiYnJkSNHaJreuHHjoEGDjI2N/fz8mMfy7O3tR48eTVHUoEGDLl++TNN0cHAwi8UihBgZGf300089dlJ6iSUplYmkr/3888+Zzuvp6c2ePVvewk8XLlwwNTUVf7JsNvv1118/evQoLUOtn/r6+mXLlpmamurr60+aNGnLli2EECsrq8LCQpqmpdSB6rJm06effsocWJqmw8PDmb1gsVjOzs4//PBD7z6US5cuOTg4MN22sLDw8/Pr3Jl+d+SPHz/u6uqqq6vL4XCYnWVuo33zzTejoqKePn3a41eRoZl3HqpCj78P8IrRzO+25nWoP/xhaEiJpQ5SUlIkn6F8+fJlcHCwjo6OuDAhqIjaj7xm/rioQr/4fQAl0szv9it+jVN1NK3E0uPHjwMDAyXrmXA4HBsbm9bW1tbWVh6Pp8a+vdpw5AEGmlf8Gmcv/P7771T3VFSgTnE8Ho/NZqempj558qS1tfXhw4cHDhzYsmWLv78/LpKpFI68xjp37lxoaKhk7bbFixdLNvD29jYwMNDS0ho5cuSNGzfU1U9CSHt7e2JiIlMOoTvNzc1OTk7h4eFqjxwfH+/k5MTj8fT09JycnCIiIiRvRJBSR+/48ePx8fGadtbRG+o+5e2IaPxQjOaUWOrg4sWL77zzjqGhoZaWlpGRkYeHR0pKSmtrq7r79epT+5HXzOEsVZD992HLli2+vr7iSZrs7e2Z69AnTpyQbHb69OkZM2Yov6Py+OOPPyZOnEgIcXNzk9IsJCSEEBIWFqb2yD4+Prt27RIKhfX19ZmZmWw2W3LeMel19JKSkry8vGpqamTclmZ+tzWvQxqfOAE0TR/8uDQ2Nrq7u6s9lIy/D5999pmDg4N4ikSapu3t7Q8fPsxisSwtLSUrtak9cRYUFMyePfvQoUOjR4+Wkt4uXbrEFEuQPb2pLvKsWbMkjy0zZdXDhw+Zlz3W0QsMDHR3d5fxf5aamTgxVAsAPUtNTVV8gi2lh+pSaWlpRETEtm3bJOdBJIR4eHgEBQVVVlauX79edVuXl5ub29GjRxcuXCgu8tNZU1PThg0bkpKSNCTysWPHJI8tM+eleDy2xzp6kZGRBQUF8m5UoyBxAgwUdPeF1QIDAzkcDvMQDiFk9erVenp6FEVVV1cTQoKCgtatW1dWVkZRFJ/Pl15ZT65QRLaidXJJTk6maXr69OmdV8XExDg4OBw4cODcuXPyHiJZqstt2bLFxsaGx+O5uroyp0pKERYWtnr1aqVMiqmKyCUlJcbGxuLJLzvoXEfPxMTEy8srKSmJpmlFtqtO6j3h7YxgqBZATjIOZ0kvrLZw4cIhQ4aIG+/cuZMQUlVVxbycM2eOvb29eK30ynpyheqxaJ0kWX4f7OzsnJ2dOyxkCvjQNH358mUWi2Vra/vixQu601Ct9EMkvbrc+vXrdXR0srOza2pqNm/ezGKxrl+/LstOMf7yl790OaCan58/ffp0mqaZ2bDlusap0sgtLS0VFRW7d+/W0dE5ePBgl226rKNH03RoaCiRrf4ShmoBQG2ampoSEhJmz569aNEiIyMjFxeXvXv3VldXd5glSnba2trMmZmzs7NAIKivr09LS+tFHB8fn7q6uoiIiN51o4OGhoa7d+8yk3J0yd3dPTg4uLy8fNOmTR1WyXiIPDw8DA0NzczM/P39Gxoa7t+/Twhpbm4WCASzZs2aM2eOsbFxeHg4m83u3QHp0KWgoCCBQKBgHFVEtra2trKyioyM3LFjR3fTycbFxVlYWMTExHRYPmLECEJId9ODaD4kToABQbmF1TqQrKynXkxhV2amp+7ExMQ4OjqmpKTk5+dLLpf3EElWl7t9+3ZjY+OoUaOYVTweb+jQoYofkM2bN69YsYK5iKhcikd+8OCBUCj86quvvvzyyzFjxnS+bs3U0fv2228719FjPqAnT570euvqhcQJMCCotLAakaisp17Nzc1MZ6S04XK5aWlpFEUtXbq0qalJvFyRQ9TQ0EAICQ8PFz/zfe/ePck7YnohPz+/qKho2bJligRRXWQ2m21mZubt7Z2enl5cXMxUpBeTXkePmRiE+bD6IyROgAFBpYXVJCvrqRfzi9zjI/bu7u4hISElJSXR0dHihYocIub+msTERMkrYVeuXOnFLoilpqaeP3+exWIxmZjZRGxsLEVRknV+1B6Zz+draWkVFxeLl+zevfvQoUMXLlwYNmxYl29hitv333m1kDgBBoQeC6tpa2szo469IFlZT8FQCjI3N6coqra2tseW0dHRTk5ON2/eFC9RpPactbU1l8uVnHlRcWlpaZJpWPIWHsnx5D6O/PTp0wULFkguKSkpEYlE1tbWhBCapjdu3FhUVJSTkyOl+izzATGVFfojJE6AAaHHwmp8Pv/Zs2c5OTmtra1VVVX37t2TfPugQYMePnxYXl5eX1/PJMXuKuvJG0quonU90tXVtbOzq6iokOWApKWlST5xqEjtOS6X+9FHHx05ckQgENTV1YlEooqKikePHhFC/P39hwwZooop/dQSWU9P7+zZsxcuXKirq2ttbb158+aHH36op6fHTD8kYx095gNycXFRes/7BhInwECxdevWuLi4qKiowYMHe3l52dra5uXl6enpMWtXrVo1efLk+fPnOzo6RkdHM8No7u7uDx48IISsXLnS3Nzc2dl52rRpz549I4Q0Nze7uLjweDxPT08HB4fvv/9efGVR3lDK5ePjU1xcLL54+fXXX/P5/LKysvHjx69Zs0ay5YQJE5ife1kOkUAgSExMJIS4urreuXNn//7969atI4RMnTqVqdmelJQUHBwcHx9vampqYWERFBRUU1NDCGlpaREKhbm5uV329urVq5MmTRo2bNi1a9cKCwstLCwmTpx48eJFWfZULZG5XO7EiROXLVtmaWlpYGDg5+dna2t79epV5sYoWrZHM69fv25paenq6ipLY02kymddeoPgOU4AOfX9s27qqqwny+9DSUmJtrZ2d08W9j2RSOTp6ZmamorIjOrqai6Xu2vXLlka4zlOAHh1aGyNCz6fHxUVFRUVJZ4ETo1EIlFOTk59fb3SCyv1x8iMyMjI0aNHBwYGqiJ430DiBIBXTWhoqJ+fn7+/vyx3CalUXl7e0aNHT58+Lf3R0gESmRCSkJBQUFBw6tQpNput9OB9BokTAOSzefPmtLS02tra4cOHZ2dnq7s7XYuNjQ0MDPzss8/U240pU6YcPnxYPHPvAI+cm5v78uXLvLw8ExMTpQfvS9rq7gAA9DNxcXEdnnbXTN7e3kzBLNAQM2bMmDFjhrp7oQQ44wQAAJADEicAAIAckDgBAADkgMQJAAAgByROAAAAOVC0bDMk9RmKotTdBQAA0CCalqc07nEUZoIlgAGOmRY1ODhY3R0BgI407owTAAghc+fOJYRkZmaquyMA0BGucQIAAMgBiRMAAEAOSJwAAAByQOIEAACQAxInAACAHJA4AQAA5IDECQAAIAckTgAAADkgcQIAAMgBiRMAAEAOSJwAAAByQOIEAACQAxInAACAHJA4AQAA5IDECQAAIAckTgAAADkgcQIAAMgBiRMAAEAOSJwAAAByQOIEAACQAxInAACAHJA4AQAA5IDECQAAIAckTgAAADkgcQIAAMgBiRMAAEAOSJwAAAByQOIEAACQAxInAACAHJA4AQAA5IDECQAAIAckTgAAADloq7sDAEAIIdeuXSssLBS/vHPnDiFk37594iVubm5/+ctf1NAzAPhfFE3T6u4DAJATJ074+vpqaWmxWCxCCPOHSVEUIaS9vV0kEn3zzTd/+9vf1NxLAEDiBNAQra2tgwcPrqur63KtoaFhVVUVh8Pp414BQGe4xgmgEdhs9vz587tMjVJWAUDfQ+IE0BTz589vaWnpvLy1tXXBggV93x8A6BKGagE0RXt7+7Bhw548edJhuZmZ2ePHj5lrnwCgdvhTBNAULBZr8eLFHYZkORzOkiVLkDUBNAf+GgE0SOfR2paWlvnz56urPwDQGYZqATTLiBEjSktLxS/t7OzKysrU2B8A6ABnnACaZdGiRWw2m/k3h8P58MMP1dsfAOgAZ5wAmqW0tHTEiBHil7dv33ZwcFBjfwCgA5xxAmgWPp/v5uZGURRFUW5ubsiaAJoGiRNA43zwwQdaWlpaWloffPCBuvsCAB1hqBZA4zx8+NDa2pqm6QcPHlhaWqq7OwDwP5A4FeLn56fuLsCrKS8vjxDy9ttvq7kf8IrKyspSdxf6MQzVKiQ7O7uiokLdvQDlq6ioyM7OVmMHbGxsXnvttT7YEL7DA43av9uvAJxxKoSiqIyMjLlz56q7I6BkmZmZ8+bNU+Nfx7NnzwghgwYNUvWG8B0eaNT+3X4FoJA1gCbqg5QJAL2DoVoAAAA5IHECAADIAYkTAABADkicAAAAckDiBFCaU6dOGRkZffPNN+ruiKqcO3cuNDT06NGjdnZ2zKSAixcvlmzg7e1tYGCgpaU1cuTIGzduqKufhJD29vbExEQPDw8pbZqbm52cnMLDw9UeOT4+3snJicfj6enpOTk5RURE1NXViddGRUU5OzsbGhrq6Ojw+fxPP/30xYsXzKrjx4/Hx8eLRCK5dgEUhMQJoDSv9i3+W7duTU5O3rx585w5c+7cuWNvb29qanro0KGTJ0+K25w9ezYrK8vX17e4uHjs2LHq6mpJSclbb70VEhLS2NgopVlYWNjt27c1IfIPP/ywfPny+/fvP3nyJDo6Oj4+/v333xevvXDhwieffFJeXl5dXR0XF5eUlCSeemX69OlcLnfKlCnPnz+Xa0dAEUicAErj4+NTW1vr6+ur6g01NTVJP+NRuu3bt6enp2dmZhoYGIgXJicns1isgICA2travuyMdIWFhZs2bVq5cuXo0aOlNLt8+fIvv/yiIZE5HM7q1avNzMz09fX9/Pxmzpz53XffPXr0iFmrr68fEBAwaNAgAwODuXPnzpo168yZMw8ePGDWrl271s3Nbdq0aW1tbXJtFHoNiROg/0lNTRUKhX22udLS0oiIiG3btnG5XMnlHh4eQUFBlZWV69ev77PO9MjNze3o0aMLFy7U0dHprk1TU9OGDRuSkpI0JPKxY8ckjy0zQbF4PPbEiRNaWlritYMHDyaESJ7yRkZGFhQUyLtR6DUkTgDlyM/Pt7GxoShqz549hBCBQKCnp6erq5ubm/vee+8ZGhpaWVkdOXKEaZycnMzlcs3NzT/++GMLCwsul+vh4XHt2jVmbWBgIIfDGTp0KPNy9erVenp6FEVVV1cTQoKCgtatW1dWVkZRFJ/PJ4ScOXPG0NAwNjZWRbuWnJxM0/T06dM7r4qJiXFwcDhw4MC5c+e6fC9N0wkJCa+//rqOjo6JicnMmTN///13ZpX0Q0QIEYlEW7ZssbGx4fF4rq6uGRkZytqjsLAw5gxPWQGVG7mkpMTY2Li7ORcrKyt5PN7w4cPFS0xMTLy8vJKSkl7tiwWaA4kTQDkmTZp0+fJl8ctVq1YFBwc3NTUZGBhkZGSUlZXZ2dktX768tbWVEBIYGLhkyZLGxsa1a9eWl5ffuHGjra3t3XffZcbfkpOTJefAS0lJ2bZtm/hlUlKSr6+vvb09TdOlpaWEEObekPb2dhXt2smTJx0dHXV1dTuv4vF4X3zxBYvFWr58eUNDQ+cGkZGRoaGhYWFhQqHw4sWLDx488PT0fPLkCenpEBFCNm3atGPHjsTExEePHvn6+i5YsOCnn35SfHcuXbpUVla2YMECxUMpN3Jra2tlZeWePXvOnTu3e/duDofTuU1jY+OFCxeWL1/eYe2YMWMqKysLCwt7t2mQCxIngGp5eHgYGhqamZn5+/s3NDTcv39fvEpbW5s5FXN2dhYIBPX19Wlpab3YhI+PT11dXUREhPJ6/V8NDQ137961t7fvroG7u3twcHB5efmmTZs6rGpqakpISJg9e/aiRYuMjIxcXFz27t1bXV29b98+yWZdHqLm5maBQDBr1qw5c+YYGxuHh4ez2ezeHZ8OXQoKChIIBArGUUVka2trKyuryMjIHTt2zJs3r8s2cXFxFhYWMTExHZaPGDGCEFJUVNTrrYPskDgB+ghziiA+nepg3Lhxurq64mFMzSEUCmma7vJ0UywmJsbR0TElJSU/P19yeXFx8YsXL8aNGydeMn78eA6HIx6U7kDyEN2+fbuxsXHUqFHMKh6PN3ToUMWPz+bNm1esWKGKKqeKR37w4IFQKPzqq6++/PLLMWPGdL6MfezYsczMzG+//VbyFi0G8wExp/KgakicAJpCR0enqqpK3b3oqLm5mRAi5XYYQgiXy01LS6MoaunSpU1NTeLlzDMS+vr6ko2NjY3r6+t73C4z8BseHk796d69e9IfAulRfn5+UVHRsmXLFAmiushsNtvMzMzb2zs9Pb24uDguLk5ybXp6+vbt2/Py8mxtbTu/l8fjkT8/LFA1JE4AjdDa2vr8+XMrKyt1d6Qj5he5x0fs3d3dQ0JCSkpKoqOjxQuNjY0JIR3SpIy7ydxfk5iYSEu4cuVKL3ZBLDU19fz58ywWi8nEzCZiY2MpilLw6qlyI/P5fC0treLiYvGS3bt3Hzp06MKFC8OGDevyLS0tLeTPDwtUDYkTQCPk5eXRND1hwgTmpba2dneDun3M3NycoihZntSMjo52cnK6efOmeMmoUaP09fUlM8e1a9daWlreeOONHqNZW1tzudyCgoLedbtLaWlpkmmYOb8PCwujaVpyPLmPIz99+rTD/UQlJSUikcja2poQQtP0xo0bi4qKcnJyOpy7S2I+oCFDhiiyFyAjJE4AtWlvb6+pqWlra7t161ZQUJCNjc2SJUuYVXw+/9mzZzk5Oa2trVVVVffu3ZN846BBgx4+fFheXl5fX9/a2nr69GnVPY6iq6trZ2dXUVHRY0tmwFbyiUMul7tu3bpjx44dOnSorq6uqKho5cqVFhYWAQEBskT76KOPjhw5IhAI6urqRCJRRUUFMyeAv7//kCFDVDGln1oi6+npnT179sKFC3V1da2trTdv3vzwww/19PRCQkIIIb/++uuOHTv279/PZrMpCbt27ZIMwnxALi4uSu85dIbECaAce/bsGT9+PCFk48aNM2bMEAgEiYmJhBBXV9c7d+7s379/3bp1hJCpU6eWlJQwb2lubnZxceHxeJ6eng4ODt9//734UuKqVasmT548f/58R0fH6OhoZgjO3d2deV5l5cqV5ubmzs7O06ZNe/bsmap3zcfHp7i4WHzx8uuvv+bz+WVlZePHj1+zZo1kywkTJjA/92Jbt26Ni4uLiooaPHiwl5eXra1tXl6enp4eIaTHQ5SUlBQcHBwfH29qamphYREUFFRTU0MIaWlpEQqFubm5Xfb26tWrkyZNGjZs2LVr1woLCy0sLCZOnHjx4kVZ9lQtkblc7sSJE5ctW2ZpaWlgYODn52dra3v16lXmxigZH828fv26paWlq6urLI1BUTQogBCSkZGh7l6A8jHP2qt0E8wkairdhCxk+Q6XlJRoa2sfPHiwb7rUI5FI5OnpmZqaisiM6upqLpe7a9cuWRr3wXf7lYczTgC16S9FLfh8flRUVFRUlHgSODUSiUQ5OTn19fX+/v6IzIiMjBw9enRgYKAqgkNnSJwA0LPQ0FA/Pz9/f3+1z+eel5d39OjR06dPS3+0dIBEJoQkJCQUFBScOnWKzWYrPTh0CYmzTy1btszAwICiKOXeK9jHJMsxMjgcjrm5+dtvv71z507mKhRIt3nz5rS0tNra2uHDh2dnZ6u7OzKJjY0NDAz87LPP1NuNKVOmHD58WDyR7wCPnJub+/Lly7y8PBMTE6UHh+4gcfapAwcO7N+/X929UJS4HKORkRFN0+3t7UKhMDMzc/jw4Rs3bhw5cqRSJhR9tcXFxb18+ZKm6bt370pWXtRw3t7e27dvV3cv4L9mzJgRGhoqeScz9AEkTvj/9brEI0VRxsbGb7/9dlpaWmZm5pMnT5iylErvoYL6voYlALySkDj7GkVR6u5C15RS4vH9999fsmSJUCjcu3evUnqlRH1cwxIAXlVInCpH0/TOnTsdHR11dHSMjIw2bNggXrVjxw5dXV0DAwOhULhu3TpLS8vbt2/T3dcvlF7EkUitfdhnJR6ZR/hPnz6t4TsIANBLanwU5hVAZHgGLiwsjKKozz//vKamprGxMSUlhRBy8+ZN8VpCyNq1a3fv3j179uzffvtty5YtHA7n4MGDz58/v3Xr1tixYwcPHvz48WOmfUBAgJ6e3q+//trc3FxcXDx+/HgDA4P79+8za6W/d+HChUOGDBF3bOfOnYSQqqoq5uWcOXOYEo+MEydOGBgYREVFdbdf4mucHdTV1RFCrK2tNXwHpRs4z7rJ8h2GV8nA+W6rDg6fQnr80WlsbNTV1X333XfFS5gC9x0SZ1NTk7i9vr6+v7+/uP2PP/5ICBEnsICAAMl0df36dULItm3bZHmvEvMK3X3ipGmauerZr3dw4Py4IHEONAPnu6062n12ajswlZaWNjY2TpkyRcb28tYvlCziKO97VaShoYGmaUNDwy7X9q8d1NgL0so1b9687somA0BnSJyqxcy8zNQYkkUv6heKizgqUvtQif744w9CiJOTU5dr+9cOMv83f7XNmzcvKCjI3d1d3R2BPnLlypWkpCR196J/Q+JULS6XSwh5+fKljO3lrV8oWcRRkdqHSnTmzBlCyHvvvdfl2v61g3PnzlVRZM0xb948d3f3gbCnIIbEqSDcVatao0aNYrFY//nPf2RvL1f9Qskijj2+tw9KPD5+/DgxMdHKymrp0qVdNujvOwgAgMSpWmZmZnPmzMnOzk5NTa2rq7t169a+ffuktJelfmF3RRx7fK/SSzzSNP3ixYv29naapquqqjIyMiZOnKilpZWTk9PdNU7N2UEp+wUAII1ab03q94gMdyTW19cvW7bM1NRUX19/0qRJW7ZsIYRYWVkVFhbGx8czdRatra3FNZva29t37tw5YsQINpttYmIya9Ys5tlHRkBAAJvNtrS01NbWNjQ0nDlzZllZmXit9Pc+ffp08uTJXC53+PDha9asYZ4o5fP5zMMeN27ceO2113g83qRJkx4/fnzq1CkDA4OYmJjOe3T8+HFXV1ddXV0Oh8Niscifkwe9+eabUVFRT58+FbfU5B2U/qkNnDsPZfkOw6tk4Hy3VYeiZauSCl2iKCojI6Mvrw99/PHHWVlZT58+7bMt9jEN2cHMzMx58+YNhL+Ovv8Og3oNnO+26mCotv/pL0Uce+2V30EA6NeQOAFAVufOnQsNDZWsK7d48WLJBt7e3gYGBlpaWiNHjrxx44a6+kkIaW9vT0xMlD6tf3Nzs5OTU3h4uNojx8fHOzk58Xg8PT09JyeniIgIZgYuRlRUlLOzs6GhoY6ODp/P//TTT8UVxY8fPx4fH4//a/Y1NQ8V93Okb68PhYaGcjgcQoitrW1WVlafbbfPaM4ODpzrQLJ/h7ds2eLr61tXV8e8tLe3NzU1JYScOHFCstnp06dnzJih/I7K448//pg4cSIhxM3NTUqzkJAQQkhYWJjaI/v4+OzatUsoFNbX12dmZrLZbMnpxry8vFJSUp4+fVpXV5eRkcFms6dOnSpem5SU5OXlVVNTI+O2Bs53W3Vwxtmf9NMijrJ75XdQkhLLnPVBxbTt27enp6dnZmYaGBiIFyYnJ7NYrICAAI2qIldYWLhp06aVK1eOHj1aSrPLly//8ssvGhKZw+GsXr3azMxMX1/fz89v5syZ33333aNHj5i1+vr6AQEBgwYNMjAwmDt37qxZs86cOfPgwQNm7dq1a93c3KZNm9bW1ibXRqHXkDgB1EOJZc5UXTGttLQ0IiJi27ZtzIQeYh4eHkFBQZWVlevXr1fd1uXl5uZ29OjRhQsX6ujodNemqalpw4YN8s4DoLrIx44dkzy2lpaWhBDxeOyJEyckS1UPHjyYENLY2CheEhkZWVBQgGkN+gwSJ0Dv0Uoqcya9nlqflYTrTnJyMk3T06dP77wqJibGwcHhwIED586dk/cQCQQCPT09XV3d3Nzc9957z9DQ0MrKiqmCwBCJRFu2bLGxseHxeK6urkqcATEsLIw5w1NWQOVGLikpMTY2fu2117pcW1lZyePxhg8fLl5iYmLi5eWVlJRE417ZvqHOceL+j+AZuFeUjNeBlFjmTHo9NeWWhJMky3fYzs7O2dm5w0J7e/u7d+/SNH358mUWi2Vra/vixQu60zVO6YeIKZ5z/vz52tpaoVDo6empp6fX0tLCrF2/fr2Ojk52dnZNTc3mzZtZLNb169dl2SnGX/7yly6vRObn50+fPp2maWYOZLmucao0cktLS0VFxe7du3V0dMTPPXfQ0NBgYGAQGBjYYXloaCiRKLskBa5xKg5nnAC91NTUlJCQMHv27EWLFhkZGbm4uOzdu7e6ulr65FBSaGtrM2dmzs7OAoGgvr4+LS2tF3F8fHzq6uoiIiJ6140OGhoa7t69a29v310Dd3f34ODg8vLyTZs2dVgl4yHy8PAwNDQ0MzPz9/dvaGi4f/8+IaS5uVkgEMyaNWvOnDnGxsbh4eFsNrt3B6RDl4KCggQCgYJxVBHZ2traysoqMjJyx44d3dWriYuLs7CwiIm7TcaqAAAgAElEQVSJ6bB8xIgRhJCioqJebx1kh8QJ0EsqLXMmWU9NvYRCIU3Turq6UtrExMQ4OjqmpKTk5+dLLpf3EDH3VDMTIt6+fbuxsXHUqFHMKh6PN3ToUMUPyObNm1esWMFcRFQuxSM/ePBAKBR+9dVXX3755ZgxYzpftz527FhmZua3334reYsWg/mAnjx50uutg+yQOAF6SdVlzsT11NSrubmZ6YyUNlwuNy0tjaKopUuXNjU1iZcrcogaGhoIIeHh4dSf7t27J3lHTC/k5+cXFRUtW7ZMkSCqi8xms83MzLy9vdPT04uLi+Pi4iTXpqenb9++PS8vz9bWtvN7mbktmQ8LVA2JE6CXVFrmTLKemnoxv8g9PmLv7u4eEhJSUlISHR0tXqjIIWLur0lMTJS8tnTlypVe7IJYamrq+fPnWSwWk4mZTcTGxlIUJVl1R+2R+Xy+lpZWcXGxeMnu3bsPHTp04cKFYcOGdfmWlpYW8ueHBaqGxAnQSyotcyZZT03BUAoyNzenKEqWJzWjo6OdnJxu3rwpXiJvFTlJ1tbWXC63oKCgd93uUlpammQalryFR3I8uY8jP336dMGCBZJLSkpKRCKRtbU1IYSm6Y0bNxYVFeXk5HQ4d5fEfEBDhgxRZC9ARkicAL2k9DJn3dVTkzeULCXhZKerq2tnZ1dRUSHLAUlLS5N84lCWKnJSon300UdHjhwRCAR1dXUikaiiooKZE8Df33/IkCGqmNJPLZH19PTOnj174cKFurq61tbWmzdvfvjhh3p6esz0Q7/++uuOHTv279/PZrMpCbt27ZIMwnxALi4uSu85dIbECdB7W7dujYuLi4qKGjx4sJeXl62tbV5enp6eHrN21apVkydPnj9/vqOjY3R0NDOM5u7uzsz5snLlSnNzc2dn52nTpj179owQ0tzc7OLiwuPxPD09HRwcvv/+e/GVRXlDKZePj09xcbH44uXXX3/N5/PLysrGjx+/Zs0ayZYTJkxgfu5lOUQCgSAxMZEQ4urqeufOnf37969bt44QMnXq1JKSEkJIUlJScHBwfHy8qamphYVFUFBQTU0NIaSlpUUoFObm5nbZ26tXr06aNGnYsGHXrl0rLCy0sLCYOHHixYsXZdlTtUTmcrkTJ05ctmyZpaWlgYGBn5+fra3t1atXmRujaNkezbx+/bqlpaWrq6ssjUFRqnzW5dVH8BznK6rvn3Vj5lTryy0yZPkOl5SUaGtrd/dkYd8TiUSenp6pqamIzKiuruZyubt27ZKlMZ7jVBzOOAE0hcbWuODz+VFRUVFRUeJJ4NRIJBLl5OTU19f7+/sjMiMyMnL06NGBgYGqCA6dIXECQM9CQ0P9/Pz8/f3VPp97Xl7e0aNHT58+Lf3R0gESmRCSkJBQUFBw6tQpNput9ODQJSROAPXbvHlzWlpabW3t8OHDs7Oz1d2drsXGxgYGBn722Wfq7caUKVMOHz4snrl3gEfOzc19+fJlXl6eiYmJ0oNDd7TV3QEAIHFxcR2edtdM3t7e3t7e6u4F/NeMGTNmzJih7l4MODjjBAAAkAMSJwAAgByQOAEAAOSAxAkAACAH3BykKAVnnQbNxHysmZmZ6u5IX8B3eEDBx604ipZtPifoEkVR6u4CAIDc8MuvCCROAE00d+5cMmBOeQH6F1zjBAAAkAMSJwAAgByQOAEAAOSAxAkAACAHJE4AAAA5IHECAADIAYkTAABADkicAAAAckDiBAAAkAMSJwAAgByQOAEAAOSAxAkAACAHJE4AAAA5IHECAADIAYkTAABADkicAAAAckDiBAAAkAMSJwAAgByQOAEAAOSAxAkAACAHJE4AAAA5IHECAADIAYkTAABADkicAAAAckDiBAAAkAMSJwAAgByQOAEAAOSAxAkAACAHJE4AAAA5IHECAADIAYkTAABADkicAAAAckDiBAAAkANF07S6+wAA5PDhw6mpqe3t7czLu3fvEkKGDx/OvGSxWH//+98XLlyotv4BwJ+QOAE0wq1bt9zc3KQ0KCwsdHV17bP+AEB3kDgBNIWTk9Pt27e7XMXn80tKSvq4PwDQJVzjBNAUixcvZrPZnZez2eyPPvqo7/sDAF3CGSeAprhz5w6fz+/yT7KkpITP5/d9lwCgM5xxAmgKOzu7sWPHUhQluZCiqHHjxiFrAmgOJE4ADfLBBx9oaWlJLtHS0vrggw/U1R8A6AxDtQAaRCgUWlhYiB9KIYSwWKyHDx8OGTJEjb0CAEk44wTQIObm5l5eXuKTTi0trbfffhtZE0CjIHECaJbFixdLjgMtXrxYjZ0BgM4wVAugWerq6szMzFpaWgghbDZbKBQaGxuru1MA8F844wTQLIaGhlOnTtXW1tbW1p42bRqyJoCmQeIE0DiLFi0SiUQikQiT0wJoIAzVAmic5ubmwYMH0zRdXV3N4/HU3R0A+B9InD3IzMycN2+eunsBANBHMjIy5s6dq+5eaDRtdXegf8jIyFB3F0CDzJs3LygoyN3dXXWbKCgooChKer0UVUtMTCSEBAcHq7EP0MdwniALJE6Z4P9fIGnevHnu7u4q/VbMnj2bEKKtrc6/0KysLIIv/wCDxCkLJE4ATaTelAkAUuCuWgAAADkgcQIAAMgBiRMAAEAOSJwAAAByQOIE6COnTp0yMjL65ptv1N0RVTl37lxoaOjRo0ft7OwoiqIoqsMM9d7e3gYGBlpaWiNHjrxx44a6+kkIaW9vT0xM9PDwkNKmubnZyckpPDxc7ZHj4+OdnJx4PJ6enp6Tk1NERERdXZ14bVRUlLOzs6GhoY6ODp/P//TTT1+8eMGsOn78eHx8vEgkkmsXoEdInAB95NWebGTr1q3JycmbN2+eM2fOnTt37O3tTU1NDx06dPLkSXGbs2fPZmVl+fr6FhcXjx07Vl1dLSkpeeutt0JCQhobG6U0CwsLu337tiZE/uGHH5YvX37//v0nT55ER0fHx8e///774rUXLlz45JNPysvLq6ur4+LikpKS/Pz8mFXTp0/ncrlTpkx5/vy5XDsC0iFxAvQRHx+f2tpaX19fVW+oqalJ+hmP0m3fvj09PT0zM9PAwEC8MDk5mcViBQQE1NbW9mVnpCssLNy0adPKlStHjx4tpdnly5d/+eUXDYnM4XBWr15tZmamr6/v5+c3c+bM77777tGjR8xafX39gICAQYMGGRgYzJ07d9asWWfOnHnw4AGzdu3atW5ubtOmTWtra5NroyAFEifAqyY1NVUoFPbZ5kpLSyMiIrZt28blciWXe3h4BAUFVVZWrl+/vs860yM3N7ejR48uXLhQR0enuzZNTU0bNmxISkrSkMjHjh2TPLaWlpaEEPF47IkTJ8SVzwkhgwcPJoRInvJGRkYWFBTIu1GQAokToC/k5+fb2NhQFLVnzx5CiEAg0NPT09XVzc3Nfe+99wwNDa2srI4cOcI0Tk5O5nK55ubmH3/8sYWFBZfL9fDwuHbtGrM2MDCQw+EMHTqUebl69Wo9PT2KoqqrqwkhQUFB69atKysroyiKz+cTQs6cOWNoaBgbG6uiXUtOTqZpevr06Z1XxcTEODg4HDhw4Ny5c12+l6bphISE119/XUdHx8TEZObMmb///juzSvohIoSIRKItW7bY2NjweDxXV1clzosZFhbGnOEpK6ByI5eUlBgbG7/22mtdrq2srOTxeMOHDxcvMTEx8fLySkpKerUvFvQlJE6AvjBp0qTLly+LX65atSo4OLipqcnAwCAjI6OsrMzOzm758uWtra2EkMDAwCVLljQ2Nq5du7a8vPzGjRttbW3vvvsuM/6WnJwsOQ1eSkrKtm3bxC+TkpJ8fX3t7e1pmi4tLSWEMPeGtLe3q2jXTp486ejoqKur23kVj8f74osvWCzW8uXLGxoaOjeIjIwMDQ0NCwsTCoUXL1588OCBp6fnkydPSE+HiBCyadOmHTt2JCYmPnr0yNfXd8GCBT/99JPiu3Pp0qWysrIFCxYoHkq5kVtbWysrK/fs2XPu3Lndu3dzOJzObRobGy9cuLB8+fIOa8eMGVNZWVlYWNi7TUMHSJwA6uTh4WFoaGhmZubv79/Q0HD//n3xKm1tbeZUzNnZWSAQ1NfXp6Wl9WITPj4+dXV1ERERyuv1fzU0NNy9e9fe3r67Bu7u7sHBweXl5Zs2beqwqqmpKSEhYfbs2YsWLTIyMnJxcdm7d291dfW+ffskm3V5iJqbmwUCwaxZs+bMmWNsbBweHs5ms3t3fDp0KSgoSCAQKBhHFZGtra2trKwiIyN37NjR3YyycXFxFhYWMTExHZaPGDGCEFJUVNTrrYMkJE4AjcCcIohPpzoYN26crq6ueBhTcwiFQpqmuzzdFIuJiXF0dExJScnPz5dcXlxc/OLFi3HjxomXjB8/nsPhiAelO5A8RLdv325sbBw1ahSzisfjDR06VPHjs3nz5hUrVjAXEZVL8cgPHjwQCoVfffXVl19+OWbMmM6XsY8dO5aZmfntt99K3qLFYD4g5lQeFIfECdA/6OjoVFVVqbsXHTU3NxNCpNwOQwjhcrlpaWkURS1durSpqUm8nHlGQl9fX7KxsbFxfX19j9tlBn7Dw8OpP927d0/6QyA9ys/PLyoqWrZsmSJBVBeZzWabmZl5e3unp6cXFxfHxcVJrk1PT9++fXteXp6trW3n9zLl0JkPCxSHxAnQD7S2tj5//tzKykrdHemI+UXu8RF7d3f3kJCQkpKS6Oho8UJjY2NCSIc0KeNuMvfXJCYm0hKuXLnSi10QS01NPX/+PIvFYjIxs4nY2FiKohS8eqrcyHw+X0tLq7i4WLxk9+7dhw4dunDhwrBhw7p8S0tLC/nzwwLFIXEC9AN5eXk0TU+YMIF5qa2t3d2gbh8zNzenKEqWJzWjo6OdnJxu3rwpXjJq1Ch9fX3JzHHt2rWWlpY33nijx2jW1tZcLregoKB33e5SWlqaZBpmzu/DwsJompYcT+7jyE+fPu1wP1FJSYlIJLK2tiaE0DS9cePGoqKinJycDufukpgPaMiQIYrsBYghcQJoqPb29pqamra2tlu3bgUFBdnY2CxZsoRZxefznz17lpOT09raWlVVde/ePck3Dho06OHDh+Xl5fX19a2tradPn1bd4yi6urp2dnYVFRU9tmQGbCWfOORyuevWrTt27NihQ4fq6uqKiopWrlxpYWEREBAgS7SPPvroyJEjAoGgrq5OJBJVVFQwcwL4+/sPGTJEFVP6qSWynp7e2bNnL1y4UFdX19raevPmzQ8//FBPTy8kJIQQ8uuvv+7YsWP//v1sNpuSsGvXLskgzAfk4uKi9J4PTEicAH1hz54948ePJ4Rs3LhxxowZAoEgMTGREOLq6nrnzp39+/evW7eOEDJ16tSSkhLmLc3NzS4uLjwez9PT08HB4fvvvxdfSly1atXkyZPnz5/v6OgYHR3NDMG5u7szz6usXLnS3Nzc2dl52rRpz549U/Wu+fj4FBcXiy9efv3113w+v6ysbPz48WvWrJFsOWHCBObnXmzr1q1xcXFRUVGDBw/28vKytbXNy8vT09MjhPR4iJKSkoKDg+Pj401NTS0sLIKCgmpqagghLS0tQqEwNze3y95evXp10qRJw4YNu3btWmFhoYWFxcSJEy9evCjLnqolMpfLnThx4rJlyywtLQ0MDPz8/Gxtba9evcrcGCXjo5nXr1+3tLR0dXWVpTH0jAapmKeq1d0L0CyEkIyMDJVugplETaWb6NH777///vvv99ispKREW1v74MGDfdAlWYhEIk9Pz9TUVERmVFdXc7ncXbt2ydK4D77brwCccQJoqP5S1ILP50dFRUVFRYkngVMjkUiUk5NTX1/v7++PyIzIyMjRo0cHBgaqIvjAhMTZX0mpJdTBsmXLDAwMKIqS8U4K2SN35/bt22vWrBk5cqSBgYG2traRkZGDg4OPj4+CNz3KQkrnJctdMTgcjrm5+dtvv71z505mlA96JzQ01M/Pz9/fX+3zuefl5R09evT06dPSHy0dIJEJIQkJCQUFBadOnWKz2UoPPnCp+5RX02nsUK2Xl1dKSsrTp0/r6uoyMjLYbPbUqVO7a8zM8Hnz5k2lR+7swIEDbDb7rbfeOnPmTE1NTXNzc1lZWXp6uoeHxz//+U/Z4/ROj523t7c3MjKiaZq59eb7779fsmQJRVEWFhbXr1+XcStExcNZoaGhzMP+tra2WVlZqtuQdDIO1Yp9++23GzduVF1/QF45OTlxcXFtbW2yv0XV3+1XgyamBI2isYnTx8dH8u+Bmbz0/v37XTaWK3HKFbmDK1euaGlp/d///V9ra2uHVWfOnNm9e7csQRTRY+fFiVNSVlYWi8UyNzd//vy5LFsZID8u8iZOeAUMkO+2gjBU21/1WEtIEkVRKorcQUxMjEgk+uyzz7S1tTus+utf//rJJ5/I3o3e6V3n33///SVLlgiFwr1796q2fwDQ/yFxKs3BgwfHjRvH5XL19PRsbW2ZGVLo3lZNev311ymKYrFYb7zxBvO7/+mnnxoZGXG53C+++KLz1jvUEqJpeufOnY6Ojjo6OkZGRhs2bOj1fnWILKVGVUtLy/nz501NTd98803pMdV1WKRgHpE8ffp0jy0BYKBT8xmvxpNxqJZ54Oyzzz57+vTps2fP/vnPfy5cuJCm6S1btnA4nIMHDz5//vzWrVtjx44dPHjw48ePmXeFhYURQs6fP19bWysUCj09PfX09FpaWmiabmtrs7W1tbGxkRx4DA4O7jDHGKOhocHAwCAwMFC8JCwsjKKozz//vKamprGxMSUlhcg8VCs98okTJwwMDKKiojo3/uOPPwghEyZM6DGsug4L3c1QLU3TdXV1hBBra+seO08PmOEsDNUOQAPku60gJM4eyJI4W1pajI2NJ0+eLF7S1taWlJTU2Nior6/v7+8vXv7jjz8SQsRZh8kQTU1NzEsmvZWWljIvmWScmZnJvGxoaLCxsamtre3cgbCwMAcHh7q6OuZlY2Ojrq7uu+++K24g1zVOKZGlY+ZOe+edd6Q3U9dhYXSXOGmapijK2Ni45/0cMD8uSJwD0AD5biuo44Uo6IVbt249f/78r3/9q3iJlpbW2rVrf/rpp15XTSKELFu2LDIyMikpyc/PjxBy6NChmTNnGhoadngXU0vo7Nmz4lpCpaWljY2NU6ZMUXC/OkeWjpkqs8cLiooUkyIKHBbpGhoaaJruHKc7ffBojdox87RlZmaquyMAmgWJUwmYUT6m1IMkRaomMW9csWLFzp07f/zxxzfffPMf//hHdnZ2hzbp6ekJCQl5eXmSVRGY3zumAkOvdRlZOltbWy6XywzYSqGuwyId020nJycZ2yclJSUlJcnYuF/rrmYywICFm4OUgPl1rq6u7rBckapJjMDAQDabnZiYePHiRWtra3t7e8m13dUS4nK5hJCXL1/KuR89R5ZOR0fnr3/9a3V19aVLlzqvffbsGVOPUF2HRbozZ84QQt577z0Z2w+E4SwM1Q5Asv/JDGRInEpga2s7aNCgs2fPdliuSNUkhpWV1dy5c7OzsyMiIoKCgsTLaam1hEaNGsVisf7zn//0Yl+kR+5RZGSkjo5OSEiIZL1ixi+//MI8o6KuwyLF48ePExMTraysli5dKvu7AGCAUvN/bzSejHfVMkV81qxZU1FRIRKJ6urqiouLaZreunUrm80+ePBgbW3trVu3xowZY2Fh8eLFC+ZdHe6C2b9/PyHkt99+k4zMVBpycXGRXPjLL790+Wnu3LmTaeDn56elpXXgwIHa2trCwsLJkycT2W4O6jHyqVOnDAwMYmJiuouQnZ2tq6v7xhtvnDx58vnz5y0tLXfu3Nm3bx+fz//kk0+YNuo6LDRN29vbGxoa1tfXi0Si9vZ2oVCYnp5uZ2c3dOjQn376qcfjwyA444RX1AD5bisIibMHss8ctGfPHhcXFy6Xy+Vyx4wZk5KSQtN0e3v7zp07R4wYwWazTUxMZs2adfv2baZ9SkoKMzXliBEjysrK9u3bx9yZ8tprr/3xxx+SkSdPnnzgwAHJJUVFRdIzRH19/bJly0xNTfX19SdNmrRlyxZCiJWVVWFhofS96DFyj4mTpun79++vX7/excVFX19fS0vL2Nh4zJgxf//73y9dusQ0UMthOX78uKurq66uLofDYbFYhBDmNto333wzKirq6dOn0o+MpAHy44LEOQANkO+2gigag9pSZWZmzps3D0cJJFEUlZGRwczn9wpj7lvOyspSd0eg7wyQ77aCcI0TAABADkicA8vvv/9OdU9F5QABAF4lSJwDi5OTk5SB+/T0dHV3EPqxc+fOhYaGStY9Xbx4sWQDb29vAwMDLS2tkSNHMrd3qUt7e3tiYqKHh4eUNs3NzU5OTuHh4ZoQubW1NS4ujs/nczgcY2PjUaNGlZeX9xj5+PHj8fHx/aUiej+CxAkASrB169bk5OTNmzfPmTPnzp079vb2pqamhw4dOnnypLjN2bNns7KyfH19i4uLx44dq66ulpSUvPXWWyEhIdJnuQoLC7t9+7aGRJ43b96///3vw4cPNzY2/vbbb/b29l2Wl+8Qefr06Vwud8qUKcysI6AsSJwAGqepqUn6KYtaQkmxffv29PT0zMxMyQkOk5OTWSxWQEBAbW2tqjsgu8LCwk2bNq1cuXL06NFSml2+fLm7p5v6PnJ6enpOTk5WVtZf/vIXbW1tCwuL3NzcUaNGyRJ57dq1bm5u06ZNa2trk2ujIAUSJ4DGSU1NFQqFmhaqO6WlpREREdu2bWOmrBLz8PAICgqqrKxcv369SjsgFzc3t6NHjy5cuFBHR6e7Nk1NTRs2bJB3SkXVRf7HP/4xduxYFxcXKW2kRI6MjCwoKBggM0T2DSROAJWgu685GhgYyOFwhg4dyrxcvXq1np4eRVHMrI1BQUHr1q0rKyujKIrP5ycnJ3O5XHNz848//tjCwoLL5Xp4eIgnxJcrFJFaTrXXkpOTaZqePn1651UxMTEODg4HDhw4d+6cvEdJemVWQohIJNqyZYuNjQ2Px3N1dWUeuVaKsLCw1atXKzjbs7Iit7S0XL16VfpZrPTIJiYmXl5eSUlJeKxOWZA4AVQiMjIyNDQ0LCxMKBRevHjxwYMHnp6eT548IYQkJydLPieXkpKybds28cukpCRfX197e3uapktLSwMDA5csWdLY2Lh27dry8vIbN260tbW9++67Dx48kDcUIYS5T6S9vV2Je3ry5ElHR0dm2ooOeDzeF198wWKxli9f3tDQ0LmBlKO0atWq4ODgpqYmAwODjIyMsrIyOzu75cuXi+vkbNq0aceOHYmJiY8ePfL19V2wYIHkPI69dunSpbKysgULFigeSimRHz582NLS8vPPP0+ePJn5n9Prr7/OzK8ie+QxY8ZUVlYWFhb2vvcgAYkTQPmampoSEhJmz569aNEiIyMjFxeXvXv3VldX79u3r3cBtbW1mdMyZ2dngUBQX1+flpbWizg+Pj51dXURERG960ZnDQ0Nd+/e7TDPviR3d/fg4ODy8vJNmzZ1WCXjUfLw8DA0NDQzM/P3929oaLh//z4hpLm5WSAQzJo1a86cOcbGxuHh4Ww2u3fHpEOXgoKCBAKBgnGUGJm5CcjMzCw2Nra4uPjJkyczZ8785JNPvvrqK9kjjxgxghDS3dRaIC8kTgDlk7fmqFzGjRunq6srHtJUL6FQSNN0l6ebYjExMY6OjikpKfn5+ZLLFanMevv27cbGRvENMjweb+jQoYofk82bN69YscLS0lLBOEqMzFwxHTlypIeHx6BBg4yMjLZt22ZkZCT+74UskZkPiDmVB8UhcQIon4I1R3uko6NTVVWllFAKam5uJn/+uHeHy+WmpaVRFLV06VLJsjmKHCVm4Dc8PFw8fce9e/d6LKIuXX5+flFREVP8TrkUiWxhYUH+t2ohh8N57bXXysrKZI/M4/HInx8WKA6JE0D5FK85KkVra6uyQimO+UXu8RF7d3f3kJCQkpKS6Oho8UJFjhJzF0xiYqLkDB5XrlzpxS6Ipaamnj9/nsViMZmY2URsbCxFUQpePVUksr6+/ogRI3799VfJhW1tbUZGRrJHbmlpIX9+WKA4JE4A5eux5qi2trb4Jhd55eXl0TQ9YcIExUMpztzcnKIoWZ7UjI6OdnJyunnzpniJIpVZra2tuVxuQUFB77rdpbS0NMk0zJzTh4WF0TQtOZ7c95HnzZt38+bNO3fuMC8bGxvv3bvHPJ0iY2TmAxoyZIgiewFiSJwAysflctetW3fs2LFDhw7V1dUVFRWtXLnSwsIiICCAacDn8589e5aTk9Pa2lpVVXXv3j3Jtw8aNOjhw4fl5eX19fVMUmxvb6+pqWlra7t161ZQUJCNjc2SJUt6Eer06dPKfRxFV1fXzs6uoqKix5bMgK2WlpbkEulHSXq0jz766MiRIwKBoK6uTiQSVVRUPHr0iBDi7+8/ZMgQVUzpp67IISEhr7322pIlS+7fv//06dONGzc2NTV1vtlKCuYDkv4kKMgOiRNAJbZu3RoXFxcVFTV48GAvLy9bW9u8vDw9PT1m7apVqyZPnjx//nxHR8fo6GhmDM3d3Z15yGTlypXm5ubOzs7Tpk179uwZIaS5udnFxYXH43l6ejo4OHz//ffiy4ryhlI6Hx+f4uJi8cXLr7/+ms/nl5WVjR8/fs2aNZItJ0yYEBISIuNREggEiYmJhBBXV9c7d+7s379/3bp1hJCpU6eWlJQQQpKSkoKDg+Pj401NTS0sLIKCgmpqagghLS0tQqEwNze3y95evXp10qRJw4YNu3btWmFhoYWFxcSJEy9evCjLnqorsomJyQ8//GBlZTV69GhLS8sff/zx5MmTPT7ZKen69euWlpaurq6yvwWkkbeA50AjeyFrGDhI3xb7DQgIGDRoUKSNRCoAACAASURBVJ9tTkzGQtYlJSXa2toHDx7sgy7JQiQSeXp6pqamIjKjurqay+Xu2rVLlsZ9/N3up3DGCdAPaHKBCz6fHxUVFRUV1eW0431MJBLl5OTU19crvUZef4zMiIyMHD16dGBgoCqCD0xInACgqNDQUD8/P39/f7XP556Xl3f06NHTp09Lf7R0gEQmhCQkJBQUFJw6dYrNZis9+ICFxAmg0TZv3pyWllZbWzt8+PDs7Gx1d6dbsbGxgYGBn332mXq7MWXKlMOHD4sn7x3gkXNzc1++fJmXl2diYqL04AOZtro7AADSxMXFxcXFqbsXMvH29vb29lZ3L+C/ZsyYMWPGDHX34hWEM04AAAA5IHECAADIAYkTAABADkicAAAAcsDNQTLx8/NTdxdAsyQmJmZlZam7F6p19epVgi8/QCcULVFGHDq7cuVKQkKCunsBAw4zGfqYMWPU3REYcEJCQtzd3dXdC42GxAmgiebOnUsIyczMVHdHAKAjXOMEAACQAxInAACAHJA4AQAA5IDECQAAIAckTgAAADkgcQIAAMgBiRMAAEAOSJwAAAByQOIEAACQAxInAACAHJA4AQAA5IDECQAAIAckTgAAADkgcQIAAMgBiRMAAEAOSJwAAAByQOIEAACQAxInAACAHJA4AQAA5IDECQAAIAckTgAAADkgcQIAAMgBiRMAAEAOSJwAAAByQOIEAACQAxInAACAHJA4AQAA5IDECQAAIAckTgAAADkgcQIAAMgBiRMAAEAOSJwAAABy0FZ3BwCAEEIaGxtfvnwpftnS0kIIqampES/R0dHR1dVVQ88A4H9RNE2ruw8AQAQCwerVq6U0SElJWbVqVZ/1BwC6g8QJoBGqqqosLCxEIlGXa7W0tB49emRmZtbHvQKAznCNE0AjmJmZTZkyRUtLq/MqLS2td955B1kTQEMgcQJoikWLFnU5AkTT9KJFi/q+PwDQJQzVAmiK+vp6MzMzyVuEGBwOp6qqytDQUC29AoAOcMYJoCkMDAx8fX3ZbLbkQm1t7RkzZiBrAmgOJE4ADbJw4cK2tjbJJSKRaOHCherqDwB0hqFaAA3S0tIyePDg+vp68RJ9ff3q6modHR019goAJOGME0CDcDgcPz8/DofDvGSz2fPmzUPWBNAoSJwAmmXBggXMtEGEkNbW1gULFqi3PwDQAYZqATRLe3v70KFDq6qqCCGDBw9+/Phxlw93AoC64IwTQLOwWKwFCxZwOBw2m71w4UJkTQBNg8QJoHHmz5/f0tKCcVoAzfQ/1VEqKiouX76srq4AAIOmaVNTU0LI3bt3y8vL1d0dgIHOw8PDysrqv69pCRkZGerrGAAAgCbKyMiQzJVd1OPE7UIAavfrr78SQpydndXdEVlRFJWRkTF37lx1d0S1/Pz8CCFZWVnq7gj0HYqiOixBIWsATdSPUibAQIObgwAAAOSAxAkAACAHJE4AAAA5IHECAADIAYkTAABADkicAKA2p06dMjIy+uabb9TdEVU5d+5caGjo0aNH7ezsKIqiKGrx4sWSDby9vQ0MDLS0tEaOHHnjxg119ZMQ0t7enpiY6OHhIaVNc3Ozk5NTeHi4JkRubW2Ni4vj8/kcDsfY2HjUqFFdzhbSIfLx48fj4+NFIpE8e9AREicAqM2r/dT41q1bk5OTN2/ePGfOnDt37tjb25uamh46dOjkyZPiNmfPns3KyvL19S0uLh47dqy6ulpSUvLWW2+FhIQ0NjZKaRYWFnb79m0NiTxv3rx///vfhw8fbmxs/O233+zt7V+8eNFj5OnTp3O53ClTpjx//lyuzUnCc5wAoDY+Pj61tbV9sKGmpqYpU6b05ZSi27dvT09PLyws5HK54oXJycmLFy8OCAgoLi42MjLqs85IV1hYGBUVtXLlyoaGBin/lbl8+fIvv/yiIZHT09NzcnIKCwtdXFwIIRYWFrm5uTJGXrt27Z07d6ZNm3bx4kVt7d4kQZxxAsCrLzU1VSgU9tnmSktLIyIitm3bJpk1CSEeHh5BQUGVlZXr16/vs870yM3N7ejRowsXLpRSMr2pqWnDhg1JSUkaEvkf//jH2LFjmazZi8iRkZEFBQXyblQMiRMA1CM/P9/GxoaiqD179hBCBAKBnp6erq5ubm7ue++9Z2hoaGVldeTIEaZxcnIyl8s1Nzf/+OOPLSwsuFyuh4fHtWvXmLWBgYEcDmfo0KHMy9WrV+vp6VEUVV1dTQgJCgpat25dWVkZRVF8Pp8QcubMGUNDw9jYWBXtWnJyMk3T06dP77wqJibGwcHhwIED586d6/K9NE0nJCS8/vrrOjo6JiYmM2fO/P3335lV0g8RIUQkEm3ZssXGxobH47m6uipx+vGwsLDVq1ebmZkpK6AikVtaWq5evTp69OheRzYxMfHy8kpKSurdxQIkTgBQj0mTJkmOna5atSo4OLipqcnAwCAjI6OsrMzOzm758uWtra2EkMDAwCVLljQ2Nq5du7a8vPzGjRttbW3vvvvugwcPCCHJycmS0+SmpKRs27ZN/DIpKcnX19fe3p6m6dLSUkIIc29Ie3u7inbt5MmTjo6Ourq6nVfxeLwvvviCxWItX768oaGhc4PIyMjQ0NCwsDChUHjx4sUHDx54eno+efKE9HSICCGbNm3asWNHYmLio0ePfH19FyxY8NNPPym+O5cuXSorK1NFkbveRX748GFLS8vPP/88efJk5n9Rr7/+ekpKimQW7DHymDFjKisrCwsLe9FtJE4A0CweHh6GhoZmZmb+/v4NDQ33798Xr9LW1mZOxZydnQUCQX19fVpaWi824ePjU1dXFxERobxe/1dDQ8Pdu3ft7e27a+Du7h4cHFxeXr5p06YOq5qamhISEmbPnr1o0SIjIyMXF5e9e/dWV1fv27dPslmXh6i5uVkgEMyaNWvOnDnGxsbh4eFsNrt3x6dDl4KCggQCgYJxlBiZuQnIzMwsNja2uLj4yZMnM2fO/OSTT7766ivZI48YMYIQUlRU1IueI3ECgIbicDiEEPHpVAfjxo3T1dUVD2NqDqFQSNN0l6ebYjExMY6OjikpKfn5+ZLLi4uLX7x4MW7cOPGS8ePHczgc8aB0B5KH6Pbt2/8fe3ce0NSVNgz8BBJICBB2jCAghEVkk+oUqJTyMrUWXtwV1NrBjlZxYbNW2ZRFUNQRioJWy9BWqSwu6IhWRysvolXbyiZtKYuAqJVNhJLQkJDvj/OZybBkJwny/P4yN/c+OffmmIe7nPMwmUwnJyf8FoVCmTJliuzHJyYm5uOPPzYzM5Mxjhwj4zumM2fO9PLyMjAwoNFoiYmJNBqN/+eFOJHxF4RP5SUFiRMAMFFpamp2dHQouxXDDQwMoFc/7mMhk8m5ubkEAuGjjz5isVj85XiMhLa2tuDKenp6fX19Ij8XX/iNi4sjvNLS0iJ8EIhI5eXlNTU169atkyWI3CPT6XSEEL6BjWloaFhaWjY2NoofmUKhoFdflqQgcQIAJqTBwcGenh5zc3NlN2Q4/Isscoi9p6dnVFRUfX19cnIyf6Genh5CaFiaFHM38VMw6enpgiWXv//+eyl2gS8nJ+fGjRtqamo4E+OPSElJIRAIMt49lSWytra2ra0trlnLx+Fw8AgfMSOz2Wz06suSFCROAMCEVFpayuPxPDw88EsikTjWRV0FMzExIRAI4oxPTU5OdnBwqKio4C9xcnLS1tYW/H2/d+8em81+4403REabNm0amUyurKyUrtmjys3NFUzD+Pw+NjaWx+MJXk9WfOSgoKCKioqmpib8kslktrS04NEpYkbGX5CpqakUjYfECQCYMIaGhl68eMHhcKqrqyMiIiwsLEJCQvBbDAaju7u7uLh4cHCwo6OjpaVFcEMDA4OnT582Nzf39fUNDg5euXJl/IajaGlpWVtbt7W1iVwTX7BVV1cXXLJt27Zz586dOnWqt7e3pqYmNDSUTqdv2LBBnGhr1649ffp0dnZ2b28vl8tta2t79uwZQig4ONjU1HQ8pvRTVuSoqChLS8uQkJDW1taurq4dO3awWKyRD1sJgb8g4SNBxwKJEwCgHEeOHJkzZw5CaMeOHQsXLszOzk5PT0cIubi4NDU1nThxYtu2bQih+fPn19fX400GBgacnZ0pFIq3t7ednd3Nmzf5txI3bdrk6+u7cuVKe3v75ORkfAnO09MTj1cJDQ01MTFxdHT09/fv7u4e710LCAiora3l37w8f/48g8FobGycM2fO1q1bBdf08PCIiooSXLJ79+7U1NSkpCQjIyMfHx8rK6vS0lIqlYoQEnmIMjIyIiMj09LSDA0N6XR6RETEixcvEEJsNru9vX3UuXUQQnfv3p07d+7UqVPv3btXVVVFp9PfeuutsrIycfZUWZH19fVv3bplbm7u5uZmZmZ2//79kpISkSM7Bf3www9mZmYuLi7ib/Ifgqe0eLQsDwAAJIQQKigoGNeP2LBhg4GBwbh+hEjLli1btmyZyNXq6+uJROLJkycV0CRxcLlcb2/vnJwciIx1dnaSyeSDBw+Ks/LIvg1nnACACUPGohYKw2AwkpKSkpKSRp12XMG4XG5xcXFfX19wcDBExhISEtzc3MLCwqTbXOLEOWfOHHV1dYnOiMW3du1aMplMIBCke0RY1Rw8eBA/JnDs2DG8RL5FlBRWkikpKcnR0VFXV1dTU5PBYHz66adi/hwIVlPCiESikZHRX//613PnzsmrecK7jYpXdHptOgkYJjo6evny5cHBwYqZxV6I0tLSs2fPXrlyRfjQ0kkSGSF06NChysrKy5cvk0gkKUMInn6KeanWz8/P1dVVovNi8cXGxiKEWCzWOMVXMHzj4ejRo/jlpUuXdHV1L168KJfg8o0mhI+PT1ZWVldXV29vb0FBAYlEmj9/vvib29jY0Gg0/O/u7u7r1687ODgghPLz8+XVQpHdBld0QghdunRJcPmVK1cWLlwor2ZI5/XoJGicL9VGR0fjwf5WVlZFRUXj90HCiXmplu/q1as7duwYv/YASRUXF6empnI4HPE3Gdm3pbxUSyAQJN2ExWIJL2Q6GeAiSoGBgdJtPuwYyhhNfNra2vj2ko6OzooVKxYvXvztt9/iZy4kpa+v7+fn99lnnyGECgsLRa4vx26TmZmppqa2YcMGpZ8BCDdBO8l4S01N/fPPP3k83qNHj5YtW6bs5ohr3rx5+/btU3YrwH8sXLgwOjpa8ElmKUiZOKU4w5WorI8UiXkyUHBpJL5Lly4J9jMjIyOEkCwzklhZWaFXk6QIJ8duo5oVneROWZ0EgMlDysTZ0NDg4OBApVLxc+GC0y3eunXL0dGRRqORyWRnZ+erV6+i0cr6IIROnjw5e/ZsMplMpVKtrKz402eoqamVlJS8//77NBqNTqf/85//FKdJIgvu8MYu1rN//34tLS0dHZ329vZt27aZmZmFhoZSqVQ1NbU33njD1NSURCJRqVR3d3dvb288ylhPT+/TTz8VvtfDDCui1NDQQBjh3//+t5jHcFg04Tso8uBI5MmTJxQKZfr06filFBWaqqurEUI+Pj78JYrpNrJUdIJOAgD4/wSv24p/j9Pa2vrRo0eDg4MPHz588803yWTyb7/9ht8tKipKSEjo7u7u6ury8PAwNDTEy5cuXYrL+mB4NNLevXu7urq6u7s///zz1atX817drLpx40ZPT093d7e/v7+mpiauHi4Sf9uXL1+2t7d7e3tTqVQ2m43f3bVrl4aGxsmTJ3t6eqqrq93d3Y2MjH7//XfBbcPDww8fPrxkyZJffvll9+7dCKF79+719/d3dnbOnz8fIVRSUtLR0dHf348fx6qsrBS+18NuX+HLm4cPH8Zv7dy5E+/as2fP9PX1vby8uFyu+MdQMJqYOzjWwRFff3+/jo5OWFgYf8mlS5d0dHSSkpLG2kTwHieTybxy5YqlpeW8efP++OMP/jrj3W1sbGwePXrE4/Hu3LmjpqZmZWWFP33YPU7oJFJ3EjT+w1FUgaT3OMFrYGTflsPDQfjs4ZNPPhm5ZmpqKnpVK0Dw/zObzdbT0/P19eWvyeFwcE3RYU95fP311wihhw8firN7w7bNyspCCDU0NPB4PCaTqa2tHRwczF/5/v37CCH+z/3Ip0vwb2JfXx9++dVXXyGEampqBDcf9fEWwb0W8psoaPHixWQy+ddffxUeTchvoqQ7KHhwJBIbG2tnZ9fb2yv+JiPrKzk7O3/11Vf4ltVI49Ft+ImTx+PhMeNbtmzh/XfihE4iSyeBxAleVyP7NlG689RhP4I0Gg2nz2HwrdCRQ6+qq6t7enree+89/hJ1dfXw8PCxIkg3BaVgwR1Ji/WMFY3D4Yhs2Fh7PZbCwsLz58+npaXZ29tLHU2WakTiO3fuXGFh4bVr13R0dCTakEaj4TuaHA7n+fPn165dCwsLS01NLS8vx3dMBY13t9mzZ8+lS5eysrKCgoIEl0MnGUbSTpKenl5UVCTmyhPU3bt3EULLly9XdkOAMslnAgQSicT/31VSUvLOO+8YGxtramoK3uAR1Nvbi17VAVAMWYr1iEOcvR5VV1fX1q1b58yZg0+DpI423juIEMrPz9+3b19paSl+tEc6RCLRzMxs7dq1Bw8erKur27t3L16uyG4zHhWdxDEZOgkAk4Eczjg5HE53d7eFhQVCqLW1dfHixUuWLPnnP/85derUw4cPj/pfeurUqei/q6mNN1mK9Ygk5l6PKjw8vKen57vvvuM/tipdtHHdQYTQ4cOHr169+t133w372ZUanlsZFwZSfLfBFZ0OHjyYnJyMuy6CTiKzyMjIFStWyCWUysLnmq/9iTUQNPJxfTmccd68eXNoaMjd3R0hVFNTMzg4uGnTJmtrazyZy6ibWFlZGRgYXLt2TfZPF5MsxXpEEnOvRyopKcnLy4uPj585cyZesn37dumijd8O8ni8HTt21NTUFBcXyytrIoR++uknhBC+8KiUbiPfik4ivd6dBIBJRcrEyWazX758yeFwHjx4EBYWhsu7IITwH+/Xr18fGBior68XvHciWNZHTU0tJiamrKwsLCzsyZMnQ0NDfX19w6qSypcsxXpEErLXQvT29m7cuNHNzQ2XwhkYGPjxxx8rKyvFPIbD7jyN3w7+/PPP+/fvP3HiBIlEEhwUcfDgQbyCmBWaWCzW0NAQj8d7+vRpbm5uXFyckZFRZGQkUlK3kW9FJ5Fe704CwOQi+KSQmE/V5ubm+vr6mpiYEIlEQ0PDlStXtrS08N/dsWOHgYGBnp7e8uXL8egxGxub1tbWBw8eWFpaUiiUuXPn4sffjxw54uzsTCaTyWTyrFmzsrKy0tLScDEgW1vbxsbGU6dO6evrI4TMzc1FPliblZWFZzXE2x4/flxXVxchZGlpiYfKDA0NHThwwNbWlkQi6evrL168uK6uDm/L/9xp06bhggYZGRk4mpWV1a1bt/bt24dri5uamubl5eXn5+Pyp/r6+qdPnx5rryMiIvBqVCp1yZIlhw8fnjJlCkJIS0trwYIF/MQjyN/fX8xjGBcXJxhN+A6KPDhC1NTUjNpzDhw4gFe4fPmyjo7Onj17Rm577ty5kY/Uampq2trabtq0qbW1VQHdht8GIyMj/CStoO3btwsOR4FOIl0n4cFTteD1NbJvE/BSrLCwMCgoSHAJAACIg0AgFBQUwD1O8PoZ2behrBgAAAAggQmTOH/99deRc4/xjVPNtskADiwA4+f69evR0dEqXtsOGxoaSk9PF15TYWBgwMHBIS4uThUiDw4OpqamMhgMDQ0NPT09Jyen5uZmkZEvXryYlpYmY2FXOQxHUQwHBwe4hjwe4MACME52795dUVGRl5eno6OzdOlSBoPR09Nz6tSp4ODggIAAvM61a9e+/fbbY8eOFRcXK7Gp9fX1a9euvX37tqurq5DVYmNj6+rqVCRyUFDQzz//nJeX98Ybb3R0dGzcuHHUOsHDIi9YsODRo0d+fn7FxcVSDwqfMGecAIDJTI4F5hRT4nDfvn35+fmFhYWC02ypZm27qqqqnTt3hoaGurm5CVntzp07Dx8+VJHI+fn5xcXFRUVFb775JpFIpNPpFy5ccHJyEidyeHi4q6urv78/f5IvSUHiBABMAHIsl6aAymsNDQ3x8fGJiYlkMllwuWrWtnN1dT179uzq1as1NTXHWofFYm3fvj0jI0NFIh89etTd3R3PoyJF5ISEhMrKSkk/lA8SJwBAQXhjFzULCwvT0NDAg2cQQps3b6ZSqQQCAU8UNaxcWmZmJplMNjEx2bhxI51OJ5PJXl5e/MGsEoVCUtXFEykzM5PH4y1YsGDkW7LUthNZ+o3L5e7atcvCwoJCobi4uOARhnIRGxu7efNmY2NjeQWUJTKbzb57967ws1jhkfX19X18fHCJCMmaixCCxAkAUJiEhITo6OjY2Nj29vaysrLHjx97e3s/f/4cIZSZmSn4uH9WVlZiYiL/ZUZGRmBgIK760tDQEBYWFhISwmQyw8PDm5ubHzx4wOFw3n33XVwKRqJQ6NXk+ENDQ3Lc05KSEnt7ezwudhgKhfLll1+qqamtX7++v79/5ApCjtKmTZsiIyNZLJaOjk5BQUFjY6O1tfX69ev5M13s3Llz//796enpz549CwwMXLVqleBEUVK7fft2Y2PjqlWrZA8ll8hPnz5ls9k//fSTr68v/stpxowZWVlZgllQZORZs2Y9efKkqqpKimZD4gQAKAKLxTp06NCSJUs++OADGo3m7Ox87Nixzs7O48ePSxeQSCTi0zJHR8fs7Oy+vr7c3Fwp4gQEBPT29sbHx0vXjJH6+/sfPXo0cuoPPk9Pz8jIyObmZjwhlCAxj5KXl5eurq6xsXFwcHB/f39raytCaGBgIDs7e/HixUuXLtXT04uLiyORSNIdk2FNioiIyM7OljGOHCPjh4CMjY1TUlJqa2ufP3++aNGiLVu2fPPNN+JHtrW1RQiNNcGLcJA4AQCKIHvVNiFmz56tpaXFv6SpXLgw6qinm3x79uyxt7fPysoqLy8XXC5L6be6ujomk8l/QIZCoUyZMkX2YxITE/Pxxx+bmZnJGEeOkfEd05kzZ3p5eRkYGNBotMTERBqNxv/zQpzI+AvCp/KSgsQJAFCE8S5qpqmp2dHRIZdQMhoYGECvftzHMh617fCF37i4OP447JaWFiaTKd1eYOXl5TU1NevWrZMliNwj0+l09N+FkjQ0NCwtLRsbG8WPjGfQxF+WpCBxAgAUYVyLmg0ODsqxPpqM8C+yyCH2uLZdfX19cnIyf6EsRwk/BZOeni44q+r3338vxS7w5eTk3LhxQ01NDWdi/BEpKSkEAkHGu6eyRNbW1ra1tR1W4IHD4eDJosWMzGaz0asvS1KQOAEAiiCyqBmRSBxWzkV8paWlPB7Pw8ND9lCyMzExIRAI4ozUlG9tu2nTppHJ5MrKSumaParc3FzBNIzP6WNjY3k8nuD1ZMVHDgoKqqioaGpqwi+ZTGZLSwsenSJmZPwF4RILkoLECQBQBJFFzRgMRnd3d3Fx8eDgYEdHR0tLi+DmI8ulDQ0NvXjxgsPhVFdXR0REWFhY4OKGkoYSsy6e+LS0tKytrdva2kSuKd/admQyee3atadPn87Ozu7t7eVyuW1tbc+ePUMIBQcHm5qajseUfsqKHBUVhctZtra2dnV17dixg8VijXzYSgj8BQkfCToWSJwAAAXZvXt3ampqUlKSkZGRj4+PlZVVaWkplUrF727atMnX13flypX29vbJycn4GpqnpyceZBIaGmpiYuLo6Ojv79/d3Y0QGhgYcHZ2plAo3t7ednZ2N2/e5N9WlDSU3AUEBNTW1vJvXp4/f57BYDQ2Ns6ZM2fr1q2Ca3p4eERFRYl5lLKzs9PT0xFCLi4uTU1NJ06c2LZtG0Jo/vz59fX1CKGMjIzIyMi0tDRDQ0M6nR4REfHixQuEEJvNbm9vv3DhwqitvXv37ty5c6dOnXrv3r2qqio6nf7WW2+VlZWJs6fKiqyvr3/r1i1zc3M3NzczM7P79++XlJSIHNkp6IcffjAzM3NxcRF/k/8QPKUVsx4nAAAMgxRbj3PDhg0GBgYK+zg+Metx1tfXE4lEXLdVFXC5XG9v75ycHIiMdXZ2ksnkgwcPirPyyL4NZ5wAgAlJxgIX44rBYCQlJSUlJY067biCcbnc4uLivr4+uRc7moiRsYSEBDc3t7CwMOk2h8QJAADyFx0dvXz58uDgYKXP515aWnr27NkrV64IH1o6SSIjhA4dOlRZWXn58mUSiSRdBEicAIAJJiYmJjc39+XLl9OnTz9z5oyymzOmlJSUsLCwvXv3KrcZfn5+eXl5/Ml7J3nkCxcu/Pnnn6Wlpfr6+lIHmTD1OAEAAEtNTU1NTVV2K8Qyb968efPmKbsV4D8WLly4cOFCGYPAGScAAAAgAUicAAAAgAQgcQIAAAASgMQJAAAASAASJwAAACCBUZ6qJRAIim8HAGCiCwoKCgoKUnYrFAF+JCc5Ap5PCGtra7tz544SWwMAwPCUpJGRkcpuCAAAeXl5CVZ2+6/ECQBQEStWrEAIFRYWKrshAIDh4B4nAAAAIAFInAAAAIAEIHECAAAAEoDECQAAAEgAEicAAAAgAUicAAAAgAQgcQIAAAASgMQJAAAASAASJwAAACABSJwAAACABCBxAgAAABKAxAkAAABIABInAAAAIAFInAAAAIAEIHECAAAAEoDECQAAAEgAEicAAAAgAUicAAAAgAQgcQIAAAASgMQJAAAASAASJwAAACABSJwAAACABCBxAgAAABKAxAkAAABIABInAAAAIAFInAAAAIAEIHECAAAAEoDECQAAAEgAEicAAAAgAUicAAAAgAQgcQIAAAASgMQJAAAASICo7AYAABBC6N69e1VVVfyXTU1NCKHjx4/zl7i6ur75J3a5GAAAIABJREFU5ptKaBkA4L8ReDyestsAAECXLl0KDAxUV1dXU1NDCOH/mAQCASE0NDTE5XL/9a9//e///q+SWwkAgMQJgIoYHBw0MjLq7e0d9V1dXd2Ojg4NDQ0FtwoAMBLc4wRAJZBIpJUrV46aGoW8BQBQPEicAKiKlStXstnskcsHBwdXrVql+PYAAEYFl2oBUBVDQ0NTp059/vz5sOXGxsa///47vvcJAFA6+K8IgKpQU1Nbs2bNsEuyGhoaISEhkDUBUB3wvxEAFTLyai2bzV65cqWy2gMAGAku1QKgWmxtbRsaGvgvra2tGxsbldgeAMAwcMYJgGr54IMPSCQS/reGhsbf/vY35bYHADAMnHECoFoaGhpsbW35L+vq6uzs7JTYHgDAMHDGCYBqYTAYrq6uBAKBQCC4urpC1gRA1UDiBEDlfPjhh+rq6urq6h9++KGy2wIAGA4u1QKgcp4+fTpt2jQej/f48WMzMzNlNwcA8F8gcYrw/fffHzp0SNmtAJNOaWkpQuidd95RcjvA5BMVFeXp6ansVqg0uFQrwuPHj8+cOaPsVgDVcubMmba2tnH9CAsLC0tLy3H9CJHu3r179+5d5bYBKNiZM2ceP36s7FaoOqjHKZaioiJlNwGoEAKBEBkZuWLFivH7iO7uboSQgYHB+H2ESMuXL0fQ+ScZXMkOCAeJEwBVpNyUCQAQAi7VAgAAABKAxAkAAABIABInAAAAIAFInAAAAIAEIHECoCCXL1+m0Wj/+te/lN2Q8XL9+vXo6OizZ89aW1vjKQPXrFkjuMK8efN0dHTU1dVnzpz54MEDZbUTITQ0NJSenu7l5SVknYGBAQcHh7i4OFWIPDg4mJqaymAwNDQ09PT0nJycmpubRUa+ePFiWloal8uVZA+AaJA4AVCQ13uykd27d2dmZsbExCxdurSpqcnGxsbQ0PDUqVMlJSX8da5du1ZUVBQYGFhbW+vu7q6sptbX17/99ttRUVFMJlPIarGxsXV1dSoSOSgo6Ouvv87Ly2Mymb/88ouNjc0ff/whMvKCBQvIZLKfn19PT49EHweEg+EoAChIQEDAy5cvFfBBLBbLz8/vzp07CvgsbN++ffn5+VVVVWQymb8wMzNzzZo1GzZsqK2tpdFoCmuMcFVVVUlJSaGhof39/UL+lLlz587Dhw9VJHJ+fn5xcXFVVZWzszNCiE6nX7hwQczI4eHhTU1N/v7+ZWVlRCL84MsHnHEC8LrJyclpb29X2Mc1NDTEx8cnJiYKZk2EkJeXV0RExJMnTz755BOFNUYkV1fXs2fPrl69WlNTc6x1WCzW9u3bMzIyVCTy0aNH3d3dcdaUInJCQkJlZaWkHwqEgMQJgCKUl5dbWFgQCIQjR44ghLKzs6lUqpaW1oULF95//31dXV1zc/PTp0/jlTMzM8lksomJycaNG+l0OplM9vLyunfvHn43LCxMQ0NjypQp+OXmzZupVCqBQOjs7EQIRUREbNu2rbGxkUAgMBgMhNC3336rq6ubkpIyTruWmZnJ4/EWLFgw8q09e/bY2dl98cUX169fH3VbHo936NChGTNmaGpq6uvrL1q06Ndff8VvCT9ECCEul7tr1y4LCwsKheLi4lJQUCCvPYqNjd28ebOxsbG8AsoSmc1m3717183NTerI+vr6Pj4+GRkZr/fNAkWCxAmAIsydO1fw2ummTZsiIyNZLJaOjk5BQUFjY6O1tfX69esHBwcRQmFhYSEhIUwmMzw8vLm5+cGDBxwO591338WTiGZmZgrO9peVlZWYmMh/mZGRERgYaGNjw+PxGhoaEEL42ZChoaFx2rWSkhJ7e3stLa2Rb1EolC+//FJNTW39+vX9/f0jV0hISIiOjo6NjW1vby8rK3v8+LG3t/fz58+RqEOEENq5c+f+/fvT09OfPXsWGBi4atWqH3/8UfbduX37dmNj46pVq2QPJZfIT58+ZbPZP/30k6+vL/4rasaMGVlZWYJZUGTkWbNmPXnypKqqSvrWAwGQOAFQJi8vL11dXWNj4+Dg4P7+/tbWVv5bRCIRn4o5OjpmZ2f39fXl5uZK8REBAQG9vb3x8fHya/V/9Pf3P3r0yMbGZqwVPD09IyMjm5ubd+7cOewtFot16NChJUuWfPDBBzQazdnZ+dixY52dncePHxdcbdRDNDAwkJ2dvXjx4qVLl+rp6cXFxZFIJOmOz7AmRUREZGdnyxhHjpHxQ0DGxsYpKSm1tbXPnz9ftGjRli1bvvnmG/Ej29raIoRqamqkajsYDhInACpBQ0MDIcQ/nRpm9uzZWlpa/MuYqqO9vZ3H4416usm3Z88ee3v7rKys8vJyweW1tbV//PHH7Nmz+UvmzJmjoaHBvyg9jOAhqqurYzKZTk5O+C0KhTJlyhTZj09MTMzHH388HjVQpY6M75jOnDnTy8vLwMCARqMlJibSaDT+nxfiRMZfED6VB7KDxAnAxKCpqdnR0aHsVgw3MDCAXv24j4VMJufm5hIIhI8++ojFYvGX4zES2tragivr6en19fWJ/Fx84TcuLo7wSktLi/BBICKVl5fX1NSsW7dOliByj0yn0xFC+AY2pqGhYWlp2djYKH5kCoWCXn1ZQHaQOAGYAAYHB3t6eszNzZXdkOHwL7LIIfaenp5RUVH19fXJycn8hXp6egihYWlSzN3ET8Gkp6fzBHz//fdS7AJfTk7OjRs31NTUcCbGH5GSkkIgEGS8eypLZG1tbVtb259//llwIYfDwSN8xIzMZrPRqy8LyA4SJwATQGlpKY/H8/DwwC+JROJYF3UVzMTEhEAgiDM+NTk52cHBoaKigr/EyclJW1tb8Pf93r17bDb7jTfeEBlt2rRpZDK5srJSumaPKjc3VzAN4/P72NhYHo8neD1Z8ZGDgoIqKiqamprwSyaT2dLSgkeniBkZf0Gmpqay7AXgg8QJgIoaGhp68eIFh8Oprq6OiIiwsLAICQnBbzEYjO7u7uLi4sHBwY6OjpaWFsENDQwMnj592tzc3NfXNzg4eOXKlfEbjqKlpWVtbd3W1iZyTXzBVl1dXXDJtm3bzp07d+rUqd7e3pqamtDQUDqdvmHDBnGirV279vTp09nZ2b29vVwut62t7dmzZwih4OBgU1PT8ZjST1mRo6KiLC0tQ0JCWltbu7q6duzYwWKxRj5sJQT+goSPBAXig8QJgCIcOXJkzpw5CKEdO3YsXLgwOzs7PT0dIeTi4tLU1HTixIlt27YhhObPn19fX483GRgYcHZ2plAo3t7ednZ2N2/e5N9K3LRpk6+v78qVK+3t7ZOTk/ElOE9PTzxeJTQ01MTExNHR0d/fv7u7e7x3LSAgoLa2ln/z8vz58wwGo7Gxcc6cOVu3bhVc08PDIyoqSnDJ7t27U1NTk5KSjIyMfHx8rKysSktLqVQqQkjkIcrIyIiMjExLSzM0NKTT6RERES9evEAIsdns9vb2UefWQQjdvXt37ty5U6dOvXfvXlVVFZ1Of+utt8rKysTZU2VF1tfXv3Xrlrm5uZubm5mZ2f3790tKSkSO7BT0ww8/mJmZubi4iL8JEIYHhMKjqpXdCqBaEEIFBQXj+hEbNmwwMDAY148QadmyZcuWLRO5Wn19PZFIPHnypAKaJA4ul+vt7Z2TkwORsc7OTjKZfPDgQXFWVkDffg3AGScAKmqiFLVgMBhJSUlJSUmjTjuuYFwut7i4uK+vLzg4GCJjCQkJbm5uYWFh4xF8coLECQCQVXR09PLly4ODgxUzi70QpaWlZ8+evXLlivChpZMkMkLo0KFDlZWVly9fJpFIcg8+aUHinKiSkpIcHR11dXU1NTUZDMann3461t/769at09HRIRAIYj6CmJaW5uDgQKFQqFSqg4NDfHx8b2+vRG2rq6vbunXrzJkzdXR0iEQijUazs7MLCAiQcbSAOIQcFsE6kZiGhoaJick777xz4MABfHtMRcTExOTm5r58+XL69OlnzpxRdnPEkpKSEhYWtnfvXuU2w8/PLy8vjz+R7ySPfOHChT///LO0tFRfX1/uwSc1ZV8rVnUqe4/Tx8cnKyurq6urt7e3oKCARCLNnz9/rJXx1NgVFRXiRA4ICDh48GB7e3tfX19hYSGJRHr33XfFb9gXX3xBIpHefvvtb7/99sWLFwMDA42Njfn5+V5eXp9//rn4caQj8rDY2NjQaDQej4efWb1582ZISAiBQKDT6T/88IOYn4Imx30gMe9xgtfJJOnbMoLybBOVtrb2hg0b8MP9K1asOHv2bGFh4ePHj6dNmyZjZA0Njc2bN+MSUcuXLy8qKioqKnr27BmewUS4u3fvbtiwwcfH5+rVq/zif9bW1tbW1np6evznRceP+IeFQCDo6em9884777zzTkBAQFBQUEBAwG+//aY6lSMBAKoJLtVOVJcuXRIcEmdkZIQQGmvKMQKBIH7kc+fOCRZWxHNgivncx549e7hc7t69e0eWzH3vvfe2bNkifjOkI9Fh4Vu2bFlISEh7e/uxY8fGt30AgIkPEqfcnDx5cvbs2WQymUqlWllZ4anFeNKWG5wxYwaBQFBTU3vjjTfw7/6nn35Ko9HIZPKXX3458tOfPHlCoVCmT5+OX/J4vAMHDtjb22tqatJotO3bt0u9X/X19Xp6epaWlvilkOKObDb7xo0bhoaGf/nLX4THVNZhEQLPLXDlyhWRawIAJjslXypWeWLe48Qjtffu3dvV1dXd3f3555+vXr2ax+Pt2rVLQ0Pj5MmTPT091dXV7u7uRkZGv//+O94qNjYWIXTjxo2XL1+2t7d7e3tTqVQ2m83j8TgcjpWVlYWFBYfD4X9KZGTksMk5sf7+fh0dnbCwMP6S2NhYAoHwj3/848WLF0wmMysrC4l9jxNjs9ltbW2HDx/W1NQUHKJ36dIlHR2dpKSkkZv89ttvCCEPDw+RwZV1WHgC9ziHwQ9ATZs2TWTjeZPmPhDc45yEJknflhEkThHESZxsNltPT8/X15e/hMPhZGRkMJlMbW3t4OBg/vL79+8jhPhZB2cIFouFX+L01tDQgF/iZFxYWIhf9vf3W1hYvHz5cmQDYmNj7ezsent78Usmk6mlpSX4RI9EDwdheFpLQ0PDzz77DCctkfCko3/961+Fr6asw4KNlTh5PB6+6yl6PyfNjwskzklokvRtGcGlWjmorq7u6el57733+EvU1dXDw8NlKTeIEFq3bh2NRsvIyMAvT506tWjRIl1d3WFbnTt3rrCw8OrVqzo6OnhJQ0MDk8n08/OTZaceP37c3t7+zTfffPXVV7NmzWpvbxe5Ca4PJfKGorIOi3D9/f08Hm9knLEEBQURXndnzpw5c+aMslsBFErM/j/JwVO1coCv8uEaSYJkKTeIN/z4448PHDhw//79v/zlL0ePHh05pC8/P//QoUOlpaVTp07lL8QTOuMCQ1IjkUjGxsbz5s2bPn26nZ1damoqP1eNxcrKikwm4wu2QijrsAiHm+3g4CDm+hEREZ6enmKuPEHhk/vIyEhlNwQoTlBQkLKbMAFA4pQD/OssWGkWk6XcIBYWFpaRkZGenh4aGjpt2jQbGxvBdw8fPnz16tXvvvtuWBLCz8T++eefEu7H6BgMhrq6em1trcg1NTU133vvvQsXLty+ffutt94a9m53d/enn376xRdfKOuwCPftt98ihN5//30x1/f09FyxYoX48SeioqIihNBrv5tAECROccClWjmwsrIyMDC4du3asOWylBvEzM3NV6xYcebMmfj4+IiICP5yHo+3Y8eOmpqa4uLikenByclJTU3t//7v/6TYl66urlWrVgkuqa+v53K5Yg4PTUhI0NTUjIqK4tfK4Hv48CEeo6KswyLE77//np6ebm5u/tFHH4m/FQBgcoLEKQeampoxMTFlZWVhYWFPnjwZGhrq6+v7+eefZSk3yLdt2zYOh/PixYv/+Z//4S/8+eef9+/ff+LECRKJJHh/4uDBgwghY2PjpUuXnjlzJicnp7e3t7q6+vjx42J+HJVKvXbt2nfffdfb2zs4OFhRUfG3v/2NSqXyq0EJL+7o5uaWl5f38OFDb2/vy5cvv3z5cnBw8NGjRydOnPj73/+OZ8tU1mHh4/F4f/zxx9DQEI/H6+joKCgoeOutt9TV1YuLi8W/xwkAmLyU+mjSBCD+lHtHjhxxdnYmk8lkMnnWrFlZWVk8Hm9oaOjAgQO2trYkEklfX3/x4sV1dXV4/aysLDyns62tbWNj4/Hjx/GvtqWl5W+//SYY2dfX94svvhBcUlNTM+q3eeDAAbxCX1/funXrDA0NtbW1586du2vXLoSQubl5VVWVyB1ZsGDB9OnTtbW1NTU1bWxsgoODa2pq+O9evnxZR0dnz549QiK0trZ+8sknzs7O2tra6urqenp6s2bN+vvf/3779m28glIOy8WLF11cXLS0tDQ0NNTU1NCryYP+8pe/JCUldXV1iTwyfGhyPHkIT9VOQpOkb8uIwOPxxiEdvz4KCwuDgoLgKAFBBAKhoKDgtb/5t3z5cvTqTieYJCZJ35YRXKoFAAAAJACJc3L59ddfhQzhGqc6umCSuH79enR0tGD5tjVr1giuMG/ePB0dHXV19ZkzZz548EBZ7UQIDQ0Npaene3l5CVlnYGDAwcEhLi5OFSIPDg6mpqYyGAwNDQ09PT0nJ6fm5maRkS9evJiWljZRKqJPIJA4JxcHBwchF+7z8/OV3UAwUe3evTszMzMmJmbp0qVNTU02NjaGhoanTp0qKSnhr3Pt2rWioqLAwMDa2lp3d3dlNbW+vv7tt9+OiooSPllHbGxsXV2dikQOCgr6+uuv8/LymEzmL7/8YmNjM2rdhWGRFyxYQCaT/fz88OBpIC+QOAFQOSwWS/gpi1JCCbFv3778/PzCwkLBeZoyMzPV1NQ2bNjw8uXL8W6A+Kqqqnbu3BkaGurm5iZktTt37jx8+FBFIufn5xcXFxcVFb355ptEIpFOp1+4cMHJyUmcyOHh4a6urv7+/hwOR6IPBUJA4gRA5eTk5Igzx6GCQ42loaEhPj4+MTFRsBodQsjLyysiIuLJkyeffPLJuDZAIq6urmfPnl29erWmpuZY67BYrO3bt4ucKkthkY8ePeru7u7s7CxkHSGRExISKisrJf1QIAQkTgDGBW/s0mlhYWEaGhpTpkzBLzdv3kylUgkEAp58KiIiYtu2bY2NjQQCgcFgZGZmkslkExOTjRs30ul0Mpns5eXFn9dXolBIaFU4qWVmZvJ4vAULFox8a8+ePXZ2dl988cX169clPUrCC8whhLhc7q5duywsLCgUiouLCx45JhexsbGbN2+WcdJKeUVms9l3794VfhYrPLK+vr6Pj09GRgaMDpAXSJwAjIuEhITo6OjY2Nj29vaysrLHjx97e3s/f/4cIZSZmSn4uH9WVlZiYiL/ZUZGRmBgoI2NDY/Ha2hoCAsLCwkJYTKZ4eHhzc3NDx484HA477777uPHjyUNhRDCz4kMDQ3JcU9LSkrs7e3x6NthKBTKl19+qaamtn79+v7+/pErCDlKmzZtioyMZLFYOjo6BQUFjY2N1tbW69ev50/3v3Pnzv3796enpz979iwwMHDVqlWC01FJ7fbt242NjcPmz5IL6SI/ffqUzWb/9NNPvr6++C+nGTNm4GHi4keeNWvWkydPqqqqpG89EACJEwD5Y7FYhw4dWrJkyQcffECj0ZydnY8dO9bZ2Sn+FE7DEIlEfFrm6OiYnZ3d19eXm5srRZyAgIDe3t74+HjpmjFSf3//o0ePhk0XLMjT0zMyMrK5uXnnzp3D3hLzKHl5eenq6hobGwcHB/f397e2tiKEBgYGsrOzFy9evHTpUj09vbi4OBKJJN0xGdakiIiI7OxsGePIMTJ+CMjY2DglJaW2tvb58+eLFi3asmXLN998I35kW1tbhNBYM4QASUHiBED+JC2dJpHZs2draWnxL2kqV3t7O4/HG/V0k2/Pnj329vZZWVnl5eWCy2UpMFdXV8dkMvkPyFAolClTpsh+TGJiYj7++GMzMzMZ48gxMr5jOnPmTC8vLwMDAxqNlpiYSKPR+H9eiBMZf0H4VB7IDhInAPInY+k0kTQ1NTs6OuQSSkYDAwPo1Y/7WMhkcm5uLoFA+OijjwRn/5flKOELv3FxcfxRyC0tLSJrwQpXXl5eU1Ozbt06WYLIPTKdTkf/XXxJQ0PD0tKysbFR/MgUCgW9+rKA7CBxAiB/spdOE2JwcFBeoWSHf5FFDrH39PSMioqqr69PTk7mL5TlKOGnYNLT0wUHIn///fdS7AJfTk7OjRs31NTUcCbGH5GSkkIgEGS8eypLZG1tbVtb259//llwIYfDodFo4kdms9no1ZcFZAeJEwD5E1k6jUgk8h9ykVRpaSmPx/Pw8JA9lOxMTEwIBII4IzWTk5MdHBwqKir4S2QpMDdt2jQymVxZWSlds0eVm5srmIbxOX1sbCyPxxO8nqz4yEFBQRUVFU1NTfglk8lsaWnBo1PEjIy/IFNTU1n2AvBB4gRA/kSWTmMwGN3d3cXFxYODgx0dHS0tLYKbGxgYPH36tLm5ua+vDyfFoaGhFy9ecDic6urqiIgICwuLkJAQKUIJrwonBS0tLWtr67a2NpFr4gu26urqgkukLjBHJpPXrl17+vTp7Ozs3t5eLpfb1tb27NkzhFBwcLCpqel4TOmnrMhRUVGWlpYhISGtra1dXV07duxgsVgjH7YSAn9BwkeCAvFB4gRgXOzevTs1NTUpKcnIyMjHx8fKyqq0tJRKpeJ3N23a5Ovru3LlSnt7++TkZHwNzdPTEw8yCQ0NNTExcXR09Pf37+7uRggNDAw4OztTKBRvb287O7ubN2/ybytKGkruAgICamtr+Tcvz58/z2AwGhsb58yZs3XrVsE1PTw8+IVdRR6l7Ozs9PR0hJCLi0tTU9OJEye2bduGEJo/f359fT1CKCMjIzIyMi0tzdDQkE6nR0REvHjxAiHEZrPb29svXLgwamvv3r07d+7cqVOn3rt3r6qqik6nv/XWW2VlZeLsqbIi6+vr37p1y9zc3M3NzczM7P79+yUlJSJHdgr64YcfzMzMXFxcxN8ECCNpHbLJRvx6nGDyQIqtWbhhwwYDAwOFfRyfmPU46+vriUTiyZMnFdAkcXC5XG9v75ycHIiMdXZ2ksnkgwcPirOygvv2BAVnnABMAKpc4ILBYCQlJSUlJY067biCcbnc4uLivr4+uZf6mYiRsYSEBDc3t7CwsPEIPjlB4gQAyCo6Onr58uXBwcFKn8+9tLT07NmzV65cET60dJJERggdOnSosrLy8uXLJBJJ7sEnLUicAKi0mJiY3Nzcly9fTp8+/cyZM8puzphSUlLCwsL27t2r3Gb4+fnl5eXxJ++d5JEvXLjw559/lpaW6uvryz34ZEZUdgMAAMKkpqampqYquxVimTdv3rx585TdCvAfCxcuXLhwobJb8RqCM04AAABAApA4AQAAAAlA4gQAAAAkAIkTAAAAkAA8HCSWwsJCZTcBqBYZ5xOfEPA8bdD5ARiGwBMoIw5GKiwsDAoKUnYrAABAQQoKClasWKHsVqg0SJwAqCL8ywVnewCoILjHCQAAAEgAEicAAAAgAUicAAAAgAQgcQIAAAASgMQJAAAASAASJwAAACABSJwAAACABCBxAgAAABKAxAkAAABIABInAAAAIAFInAAAAIAEIHECAAAAEoDECQAAAEgAEicAAAAgAUicAAAAgAQgcQIAAAASgMQJAAAASAASJwAAACABSJwAAACABCBxAgAAABKAxAkAAABIABInAAAAIAFInAAAAIAEIHECAAAAEoDECQAAAEgAEicAAAAgAUicAAAAgAQgcQIAAAASgMQJAAAASAASJwAAACABSJwAAACABCBxAgAAABKAxAkAAABIgMDj8ZTdBgAAysvLy8nJGRoawi8fPXqEEJo+fTp+qaam9ve//3316tVKax8A4BVInACohOrqaldXVyErVFVVubi4KKw9AICxQOIEQFU4ODjU1dWN+haDwaivr1dwewAAo4J7nACoijVr1pBIpJHLSSTS2rVrFd8eAMCo4IwTAFXR1NTEYDBG/S9ZX1/PYDAU3yQAwEhwxgmAqrC2tnZ3dycQCIILCQTC7NmzIWsCoDogcQKgQj788EN1dXXBJerq6h9++KGy2gMAGAku1QKgQtrb2+l0On9QCkJITU3t6dOnpqamSmwVAEAQnHECoEJMTEx8fHz4J53q6urvvPMOZE0AVAokTgBUy5o1awSvA61Zs0aJjQEAjASXagFQLb29vcbGxmw2GyFEIpHa29v19PSU3SgAwH/AGScAqkVXV3f+/PlEIpFIJPr7+0PWBEDVQOIEQOV88MEHXC6Xy+XC5LQAqCC4VAuAyhkYGDAyMuLxeJ2dnRQKRdnNAQD8N56AgoICZTcHAAAAUC0FBQWCuZI46hqKbxYAQFBlZSWBQBBeL0WlBAUFRUREeHp6Krsh4ys9PR0hFBkZqeyGAMUJCgoatmSUxLlixQqFNAYAMKYlS5YghIjEUf6HqqagoCBPT8/X/tejqKgIwY/kJCNW4gQAKN0ESpkATDbwVC0AAAAgAUicAAAAgAQgcQIAAAASgMQJAAAASAASJwBAaS5fvkyj0f71r38puyHj5fr169HR0WfPnrW2tiYQCAQCYdis/fPmzdPR0VFXV585c+aDBw+U1U6E0NDQUHp6upeXl5B1BgYGHBwc4uLiVCHy4OBgamoqg8HQ0NDQ09NzcnJqbm4WGfnixYtpaWlcLleSPRgOEicAQGle75nLdu/enZmZGRMTs3Tp0qamJhsbG0NDw1OnTpWUlPDXuXbtWlFRUWBgYG1trbu7u7KaWl9f//bbb0dFRTGZTCGrxcbG1tXVqUjkoKCgr7/+Oi8vj8lk/vLLLza4FRh4AAAgAElEQVQ2Nn/88YfIyAsWLCCTyX5+fj09PRJ9nCB45B0AoDQBAQEvX75UwAexWCw/P787d+4o4LOwffv25efnV1VVkclk/sLMzMw1a9Zs2LChtraWRqMprDHCVVVVJSUlhYaG9vf3C/lT5s6dOw8fPlSRyPn5+cXFxVVVVc7OzgghOp1+4cIFMSOHh4c3NTX5+/uXlZVJN+4LzjgBAK+/nJyc9vZ2hX1cQ0NDfHx8YmKiYNZECHl5eUVERDx58uSTTz5RWGNEcnV1PXv27OrVqzU1Ncdah8Vibd++PSMjQ0UiHz161N3dHWdNKSInJCRUVlZK+qF8kDgBAMpRXl5uYWFBIBCOHDmCEMrOzqZSqVpaWhcuXHj//fd1dXXNzc1Pnz6NV87MzCSTySYmJhs3bqTT6WQy2cvL6969e/jdsLAwDQ2NKVOm4JebN2+mUqkEAqGzsxMhFBERsW3btsbGRgKBwGAwEELffvutrq5uSkrKOO1aZmYmj8dbsGDByLf27NljZ2f3xRdfXL9+fdRteTzeoUOHZsyYoampqa+vv2jRol9//RW/JfwQIYS4XO6uXbssLCwoFIqLi4sc50+NjY3dvHmzsbGxvALKEpnNZt+9e9fNzU3qyPr6+j4+PhkZGdLdLIDECQBQjrlz5wpeO920aVNkZCSLxdLR0SkoKGhsbLS2tl6/fv3g4CBCKCwsLCQkhMlkhoeHNzc3P3jwgMPhvPvuu48fP0YIZWZmCk6Dl5WVlZiYyH+ZkZERGBhoY2PD4/EaGhoQQvjZkKGhoXHatZKSEnt7ey0trZFvUSiUL7/8Uk1Nbf369f39/SNXSEhIiI6Ojo2NbW9vLysre/z4sbe39/Pnz5GoQ4QQ2rlz5/79+9PT0589exYYGLhq1aoff/xR9t25fft2Y2PjqlWrZA8ll8hPnz5ls9k//fSTr68v/itqxowZWVlZgllQZORZs2Y9efKkqqpKimZD4gQAqBYvLy9dXV1jY+Pg4OD+/v7W1lb+W0QiEZ+KOTo6Zmdn9/X15ebmSvERAQEBvb298fHx8mv1f/T39z969MjGxmasFTw9PSMjI5ubm3fu3DnsLRaLdejQoSVLlnzwwQc0Gs3Z2fnYsWOdnZ3Hjx8XXG3UQzQwMJCdnb148eKlS5fq6enFxcWRSCTpjs+wJkVERGRnZ8sYR46R8UNAxsbGKSkptbW1z58/X7Ro0ZYtW7755hvxI9va2iKEampqpGg5JE4AgIrS0NBACPFPp4aZPXu2lpYW/zKm6mhvb+fxeKOebvLt2bPH3t4+KyurvLxccHltbe0ff/wxe/Zs/pI5c+ZoaGjwL0oPI3iI6urqmEymk5MTfotCoUyZMkX24xMTE/Pxxx+bmZnJGEeOkfEd05kzZ3p5eRkYGNBotMTERBqNxv/zQpzI+AvCp/KSgsQJAJioNDU1Ozo6lN2K4QYGBtCrH/exkMnk3NxcAoHw0UcfsVgs/nI8RkJbW1twZT09vb6+PpGfiy/8xsXFEV5paWkRPghEpPLy8pqamnXr1skSRO6R6XQ6QgjfwMY0NDQsLS0bGxvFj4xLxOMvS1KQOAEAE9Lg4GBPT4+5ubmyGzIc/kUWOcTe09MzKiqqvr4+OTmZv1BPTw8hNCxNirmb+CmY9PR0wZLL33//vRS7wJeTk3Pjxg01NTWcifFHpKSkEAgEGe+eyhJZW1vb1tb2559/FlzI4XDwCB8xI7PZbPTqy5IUJE4AwIRUWlrK4/E8PDzwSyKRONZFXQUzMTEhEAjijE9NTk52cHCoqKjgL3FyctLW1hb8fb937x6bzX7jjTdERps2bRqZTK6srJSu2aPKzc0VTMP4/D42NpbH4wleT1Z85KCgoIqKiqamJvySyWS2tLTg0SliRsZfkKmpqRSNh8QJAJgwhoaGXrx4weFwqqurIyIiLCwsQkJC8FsMBqO7u7u4uHhwcLCjo6OlpUVwQwMDg6dPnzY3N/f19Q0ODl65cmX8hqNoaWlZW1u3tbWJXBNfsFVXVxdcsm3btnPnzp06daq3t7empiY0NJROp2/YsEGcaGvXrj19+nR2dnZvby+Xy21ra3v27BlCKDg42NTUdDym9FNW5KioKEtLy5CQkNbW1q6urh07drBYrJEPWwmBvyDhI0HHAokTAKAcR44cmTNnDkJox44dCxcuzM7OTk9PRwi5uLg0NTWdOHFi27ZtCKH58+fX19fjTQYGBpydnSkUire3t52d3c2bN/m3Ejdt2uTr67ty5Up7e/vk5GR8Cc7T0xOPVwkNDTUxMXF0dPT39+/u7h7vXQsICKitreXfvDx//jyDwWhsbJwzZ87WrVsF1/Tw8IiKihJcsnv37tTU1KSkJCMjIx8fHysrq9LSUiqVihASeYgyMjIiIyPT0tIMDQ3pdHpERMSLFy8QQmw2u729fdS5dRBCd+/enTt37tSpU+/du1dVVUWn0996662ysjJx9lRZkfX19W/dumVubu7m5mZmZnb//v2SkhKRIzsF/fDDD2ZmZi4uLuJv8h+Cp7R4tCwPAAAkhBAqKCgY14/YsGGDgYHBuH6ESMuWLVu2bJnI1err64lE4smTJxXQJHFwuVxvb++cnByIjHV2dpLJ5IMHD4qz8si+DWecAIAJQ8aiFgrDYDCSkpKSkpJGnXZcwbhcbnFxcV9fX3BwMETGEhIS3NzcwsLCpNtc4sQ5Z84cdXV1ic6Ixbd27VoymUwgEKR7RFjVHDx4ED8mcOzYMbxEvkWUFFaSKS0tzcHBgUKhUKlUBweH+Pj43t5ecTYUrKaEEYlEIyOjv/71r+fOnZNX84R3GxWv6PTadBIwTHR09PLly4ODgxUzi70QpaWlZ8+evXLlivChpZMkMkLo0KFDlZWVly9fJpFIUoYQPP0U81Ktn5+fq6urROfF4ouNjUUIsViscYqvYPjGw9GjR/HLS5cu6erqXrx4US7B5RtNiICAgIMHD7a3t/f19RUWFpJIpHfffVf8zW1sbGg0Gv53d3f39evXHRwcEEL5+fnyaqHIboMrOiGELl26JLj8ypUrCxculFczpPN6dBI0zpdqo6Oj8WB/KyuroqKi8fsg4cS8VMt39erVHTt2jF97gKSKi4tTU1M5HI74m4zs21JeqiUQCJJuwmKxhBcynQxwEaXAwEDpNh92DGWMJj4NDQ08V7K2tvby5csXLVr073//Gz+tJyl9fX0/P7/PPvsMIVRYWChyfTl2m8zMTDU1tQ0bNij9DEC4CdpJxltqauqff/7J4/EePXq0bNkyZTdHXPPmzdu3b5+yWwH+Y+HChdHR0YJPMktBysQpxRmuRGV9pEjMk4GCSyPxnTt3TrA6Ep7ISpabN1ZWVujVJCnCybHbqGZFJ7lTVicBYPKQMnE2NDQ4ODhQqVT8XLjgdIu3bt1ydHSk0WhkMtnZ2fnq1atotLI+CKGTJ0/Onj2bTCZTqVQrKyv+9BlqamolJSXvv/8+jUaj0+n//Oc/xWmSyII7vLGL9ezfv19LS0tHR6e9vX3btm1mZmahoaFUKlVNTe2NN94wNTUlkUhUKtXd3d3b2xuPMtbT0/v000+F7/Uww4ooNTQ0EEb497//LeYxHBZN+A6KPDgSqa+v19PTs7S0xC+lqNBUXV2NEPLx8eEvUUy3kaWiE3QSAMD/J3jdVvx7nNbW1o8ePRocHHz48OGbb75JJpN/++03/G5RUVFCQkJ3d3dXV5eHh4ehoSFevnTpUlzWB8Ojkfbu3dvV1dXd3f3555+vXr2a9+pm1Y0bN3p6erq7u/39/TU1NXH1cJH42758+bK9vd3b25tKpbLZbPzurl27NDQ0Tp482dPTU11d7e7ubmRk9PvvvwtuGx4efvjw4SVLlvzyyy+7d+9GCN27d6+/v7+zs3P+/PkIoZKSko6Ojv7+fvw4VmVlpfC9Hnb7Cg8pO3z4MH5r586deNeePXumr6/v5eXF5XLFP4aC0cTcwbEOjjjYbHZbW9vhw4c1NTUFn7O/dOmSjo5OUlLSWBsK3uNkMplXrlyxtLScN2/eH3/8wV9nvLuNjY3No0ePeDzenTt31NTUrKys8KcPu8cJnUTqToLGfziKKpD0Hid4DYzs23J4OAifPXzyyScj10xNTUWvagUI/n9ms9l6enq+vr78NTkcDq4pOuwpj6+//hoh9PDhQ3F2b9i2WVlZCKGGhgYej8dkMrW1tYODg/kr379/HyHE/7kf+XQJ/k3s6+vDL7/66iuEUE1NjeDmoz7eIrjXQn4TBS1evJhMJv/666/Cown5TZR0BwUPjpjw3FSGhoafffaZRBl3ZH0lZ2fnr776Ct+yEn+XZek2/MTJ4/HwmPEtW7bw/jtxQieRpZNA4gSvq5F9myjVaerwH0EajYbT5zD4VujIoVfV1dU9PT3vvfcef4m6unp4ePhYEaSbglKw4I6kxXrGisbhcEQ2bKy9HkthYeH58+fT0tLs7e2ljiZLNSIxPX78uKenp6KiIjo6+vjx4999952JiYmY29JoNHxHk8PhPH/+/Nq1a2FhYampqeXl5UZGRsNWHu9us2fPnkuXLmVlZQUFBQkuh04yjKSdRMb5xCcEPE+bOM+1gdeYHBInQohEIvH/d5WUlBw4cKC2tra3t3es/3J4FCCuA6AYshTrEYc4ez2qrq6urVu3zpkzB58GSR1tvHcQIUQikYyNjefNmzd9+nQ7O7vU1NSMjAxJgxCJRDMzs7Vr13K53PXr1+/du/cf//gHUmy3wROEzp0796OPPkpLS+Mvh04io4yMDCm6xEQ07E8uMNnIYeYgDofT3d1tYWGBEGptbV28ePGUKVPu3bv38uVLwV8lQVOnTkX/XU1tvMlSrEckMfd6VOHh4T09PYITPUsXbVx3cBgGg6Gurl5bWytLEDy3Mi4MpPhuI/eKTiJNhk4Cl2rBa2lkV5dD4rx58+bQ0JC7uztCqKamZnBwcNOmTdbW1ngyl1E3sbKyMjAwuHbtmuyfLiZZivWIJOZej1RSUpKXlxcfHz9z5ky8ZPv27dJFG78d7OrqWrVqleCS+vp6Lpc7bdo0WcL+9NNPCCF84VEp3Ua+FZ1Eer07CQCTipSJk81mv3z5ksPhPHjwICwsDJd3QQjh887r168PDAzU19cL3jsRLOujpqYWExNTVlYWFhb25MmToaGhvr6+YVVJ5UuWYj0iCdlrIXp7ezdu3Ojm5oZL4QwMDPz444+VlZViHsNhV+fGbwepVOq1a9e+++47fEmwoqLib3/7G5VK5Zd0ELNCE4vFGhoa4vF4T58+zc3NjYuLMzIyioyMRErqNvKt6CTS691JAJhcBE9IxXyqNjc319fX18TEhEgkGhoarly5sqWlhf/ujh07DAwM9PT0li9fjkeP2djYtLa2PnjwwNLSkkKhzJ07Fz/+fuTIEWdnZzKZTCaTZ82alZWVlZaWhosB2draNjY2njp1Sl9fHyFkbm4u8sHarKwsPKsh3vb48eO6uroIIUtLSzxUZmho6MCBA7a2tiQSSV9ff/HixXV1dXhb/udOmzYND7TIyMjA0aysrG7durVv3z5cW9zU1DQvLy8/Px8/Yqqvr3/69Omx9joiIgKvRqVSlyxZcvjw4SlTpiCEtLS0FixYcPDgwZFfh7+/v5jHMC4uTjCa8B0UeXCEW7BgwfTp07W1tTU1NW1sbIKDg/kPjvJ4vMuXL+vo6OzZs2fkhufOnRv5SK2mpqatre2mTZtaW1sV0G34bTAyMsJP0gravn274HAU6CRSdxIEl2rBa2pk3ybwBC7gFhYWBgUF8Ua7pAsAAEIQCISCgoIVK1YouyHja/ny5QihoqIiZTcEKM7Ivg1lxQAAAAAJTJjE+euvv46ce4xvnGq2TQZwYAEAQCITJnE6ODgIuQadn5+v7AZOVHBgARg/169fj46OVvGisNjQ0FB6errwYkQDAwMODg5xcXGqEHlwcDA1NZXBYGhoaOjp6Tk5OTU3N4uMfPHixbS0NBkrok+YxAkAABPL7t27MzMzY2Jili5d2tTUhIvCnjp1qqSkhL/OtWvXioqKAgMDa2tr8aA+paivr3/77bejoqKYTKaQ1WJjY+vq6lQkclBQ0Ndff52Xl8dkMn/55RcbG5tRSzYNi7xgwQIymezn5ydOdaaxQOIEAEwAcqzMqpjawPv27cvPzy8sLNTR0eEvVM2isFVVVTt37gwNDXVzcxOy2p07dx4+fKgikfPz84uLi4uKit58800ikUin0y9cuODk5CRO5PDwcFdXV39/f/7smJKCxAkAmADkWGdUASVLGxoa4uPjExMTBQvZIlUtCuvq6nr27NnVq1dramqOtQ6Lxdq+fbukUyqOX+SjR4+6u7vjCcikiJyQkFBZWSn1DJGQOAEACsIbuxpoWFiYhoYGHnWKENq8eTOVSiUQCHiGxWF1RjMzM8lksomJycaNG+l0OplM9vLy4s8CIVEoJFVBWZEyMzN5PN6CBQtGviVLUViRNVO5XO6uXbssLCwoFIqLiwsemi8XsbGxmzdvNjY2lldAWSKz2ey7d+8KP4sVHllfX9/HxwfXVpKsuQghSJwAAIVJSEiIjo6OjY1tb28vKyt7/Pixt7f38+fPEUKZmZmC4+SysrISExP5LzMyMgIDA3G5tIaGhrCwsJCQECaTGR4e3tzc/ODBAw6H8+677+IaahKFQq+qygwNDclxT0tKSuzt7fGEEsNQKJQvv/xSTU1t/fr1/f39I1cQcpQ2bdoUGRnJYrF0dHQKCgoaGxutra3Xr1/PnyJq586d+/fvT09Pf/bsWWBg4KpVqwRnWJTa7du3Gxsbh029KRfSRX769Cmbzf7pp598fX3xX04zZszIysoSzIIiI8+aNevJkydVVVVSNBsSJwBAEVgs1qFDh5YsWfLBBx/QaDRnZ+djx451dnYeP35cuoBEIhGfljk6OmZnZ/f19eXm5koRJyAgoLe3Nz4+XrpmjNTf3//o0aORc2bxeXp6RkZGNjc345kUBYl5lLy8vHR1dY2NjYODg/v7+1tbWxFCAwMD2dnZixcvXrp0qZ6eXlxcHIlEku6YDGtSREREdna2jHHkGBk/BGRsbJySklJbW/v8+fNFixZt2bLlm2++ET+yra0tQqimpkaKlkPiBAAoguzlToWYPXu2lpYW/5KmcuGK4qOebvLt2bPH3t4+KyurvLxccLksNVPr6uqYTCb/ARkKhTJlyhTZj0lMTMzHH39sZmYmYxw5RsZ3TGfOnOnl5WVgYECj0RITE2k0Gv/PC3Ei4y8In8pLChInAEARxrsaqKamZkdHh1xCyWhgYAC9+nEfC64xQCAQPvroIxaLxV8uy1HCF37j4uL4E5i0tLQIHwQiUnl5eU1Nzbp162QJIvfIdDod/XeFQQ0NDUtLy8bGRvEj46mn8ZclKUicAABFGNdqoIODg+NUfVYK+BdZ5BB7uReFxU/BpKenC85h8v3330uxC3w5OTk3btxQU1PDmRh/REpKCoFAkPHuqSyRtbW1bW1th1VG4nA4uMqCmJHZbDZ69WVJChInAEARRFYDJRKJw+qgia+0tJTH43l4eMgeSnYmJiYEAkGckZryLQo7bdo0MplcWVkpXbNHlZubK5iG8Tl9bGwsj8cTvJ6s+MhBQUEVFRVNTU34JZPJbGlpwaNTxIyMvyBcm0hSkDgBAIogshoog8Ho7u4uLi4eHBzs6OhoaWkR3HxkndGhoaEXL15wOJzq6uqIiAgLCwtcFVjSUGIWlBWflpaWtbV1W1ubyDXlWxSWTCavXbv29OnT2dnZvb29XC63ra3t2bNnCKHg4GBTU9PxmNJPWZGjoqJwHejW1taurq4dO3awWKyRD1sJgb8g4SNBxwKJEwCgILt3705NTU1KSjIyMvLx8bGysiotLaVSqfjdTZs2+fr6rly50t7ePjk5GV9D8/T0xINMQkNDTUxMHB0d/f39u7u7EUIDAwPOzs4UCsXb29vOzu7mzZv824qShpK7gICA2tpa/s3L8+fPMxiMxsbGOXPmbN26VXBNDw8Pfk34/8fenQZEcaV7Az/V0E2zNqBsAUFZlCAqQzQRlCsJiTfREVyiYNSMyVVxRUAdZXFDIRANcImg10iYiRsgJmBUTKITosQlJgoiJoosIi4simzdbE29H+pNTw9L0wX0gvx/n6yqc06dri77oZZznl6PUlJSUlxcHCFk/PjxJSUlX3zxxYYNGwgh7777blFRESEkPj4+KCgoJiZm2LBhFhYWgYGBtbW1hJDW1taqqqqsrKxue3v16tWpU6e+8sor165dy8/Pt7CwmDJlysWLF+X5pKpq2cjI6NKlS1ZWVi4uLpaWlr/88suZM2d6Hdkp7fr165aWluPHj5e/yr9JX9LKmcgaAKATotxE1v7+/sbGxkrbnYSciayLioo0NTWZhOfqQCwWe3h4JCcno2VGTU0Nn8/fu3evPIW7ntu44gSAQamfCS4Uyt7ePiIiIiIiottpx5VMLBZnZmY2NDQMeJbAwdgyY8eOHS4uLgEBAX2rjsAJADDwQkJC5s+f7+fnp/L53HNyck6ePJmdnS17aOkQaZkQEhsbm5eXd/bsWS6X27cWEDgBYJAJDQ1NSUmpq6sbNWpURkaGqrvTo8jIyICAgE8++US13fDy8jp69Khk8t4h3nJWVlZLS0tOTo6RkVGfG9EcwA4BAChBVFRUVFSUqnshl+nTp0+fPl3VvYB/8/Hx8fHx6WcjuOIEAABgAYETAACABQROAAAAFhA4AQAAWOjm5aD58+crvx8AMNjFxcWdOHFC1b1QrKtXrxL8SA55FC2VMvvKlSuxsbEq7A0AMJiJv//yl7+ouiMAQIKDg93c3CSL/xE4AUBNLFiwgBCSnp6u6o4AQGd4xgkAAMACAicAAAALCJwAAAAsIHACAACwgMAJAADAAgInAAAACwicAAAALCBwAgAAsIDACQAAwAICJwAAAAsInAAAACwgcAIAALCAwAkAAMACAicAAAALCJwAAAAsIHACAACwgMAJAADAAgInAAAACwicAAAALCBwAgAAsIDACQAAwAICJwAAAAsInAAAACwgcAIAALCAwAkAAMACAicAAAALCJwAAAAsIHACAACwgMAJAADAAgInAAAACwicAAAALCBwAgAAsKCp6g4AACGECIXClpYWyWJrayshpLa2VrJGS0tLR0dHBT0DgP9E0TSt6j4AAElKSlqzZo2MAomJiatXr1ZafwCgJwicAGqhurrawsJCLBZ3u1VDQ+PJkycmJiZK7hUAdIVnnABqwcTExMvLS0NDo+smDQ2Nt99+G1ETQE0gcAKoi8WLF3d7B4im6cWLFyu/PwDQLdyqBVAXDQ0NJiYm0q8IMXg8XnV1tYGBgUp6BQCd4IoTQF3o6+vPmjWLy+VKr9TU1PTx8UHUBFAfCJwAamTRokXt7e3Sa8Ri8aJFi1TVHwDoCrdqAdRIa2vr8OHDGxoaJGv09PRqamq0tLRU2CsAkIYrTgA1wuPx5s+fz+PxmEUul+vr64uoCaBWEDgB1MsHH3zATBtECGlra/vggw9U2x8A6AS3agHUS0dHh7m5eXV1NSFk+PDhT58+7XZwJwCoCq44AdQLh8P54IMPeDwel8tdtGgRoiaAukHgBFA7CxcubG1txX1aAPWkguwo6enpyt8pwCBC0/SwYcMIIaWlpWVlZaruDoBaW7BggZL3qIJnnBRFKXmPAADwslJ+FFNNPs60tDTl/40AMIjcuXOHEOLk5NT/ptLT0319fYfCa4AUReG3ZUhhzm3l7xeJrAHU0YCETABQBLwcBAAAwAICJwAAAAsInAAAACwgcAIAALCAwAkAAMACAicAdOPs2bMCgeDbb79VdUcU5fz58yEhISdPnrS1taUoiqKoJUuWSBeYPn26vr6+hobG2LFjb9y4oap+EkI6Ojri4uLc3d1llGlubnZ0dAwPD1eHltva2qKiouzt7Xk8nqGhobOzc7fzeHRq+dSpUzExMWKxmM0nUA0ETgDoxss97nP79u0JCQmhoaHz5s0rKSmxs7MbNmzYkSNHzpw5Iynz/fffnzhxYtasWYWFha6urqrqalFR0X/9138FBwcLhUIZxcLCwu7evasmLfv6+n711VdHjx4VCoW///67nZ1dY2Njry17e3vz+XwvL68XL16w2p3yYRwnAHRj5syZdXV1StiRSCTy8vK6fPmyEvbFiI6OTk1Nzc/P5/P5kpUJCQlLlizx9/cvLCwUCARK64xs+fn5ERERq1atampqkvGnzOXLl2/fvq0mLaempmZmZubn548bN44QYmFhkZWVJWfL69evLykpmTFjxsWLFzU11Tc84YoTAFQpOTm5qqpKabu7f//+1q1bd+7cKR01CSHu7u6BgYGPHj3auHGj0jrTqwkTJpw8eXLRokUykpmLRKJNmzbFx8erScv79+93dXVlomYfWt6xY0deXh7bnSoZAicAdJabm2ttbU1R1L59+wghSUlJurq6Ojo6WVlZ7733noGBgZWV1fHjx5nCCQkJfD7f1NR05cqVFhYWfD7f3d392rVrzNaAgAAej2dubs4srlmzRldXl6KompoaQkhgYOCGDRuKi4spirK3tyeEnDt3zsDAIDIyUkEfLSEhgaZpb2/vrpt27949evToQ4cOnT9/vtu6NE3Hxsa++uqrWlpaRkZGs2fP/uOPP5hNsg8RIUQsFm/bts3a2lpbW3v8+PFpaWkD9YnCwsLWrFljYmIyUA32p+XW1tarV6+6uLj0uWUjI6Np06bFx8er88MCBE4A6Gzq1KnS905Xr14dFBQkEon09fXT0tKKi4ttbW2XL1/e1tZGCAkICFi6dKlQKFy/fn1ZWdmNGzfa29vfeeedhw8fEkISEhKkJ49NTEzcuXOnZDE+Pn7WrFl2dnY0Td+/f58Qwrwb0tHRoaCPdu8eNCcAACAASURBVObMmTFjxujo6HTdpK2t/Y9//IPD4SxfvrypqalrgR07doSEhISFhVVVVV28ePHhw4ceHh6VlZWkt0NECNmyZcunn34aFxf35MmTWbNmffDBB7/++mv/P87PP/9cXFysiPRzfWv58ePHra2tv/3225tvvsn8FfXqq68mJiZKR8FeW/7LX/7y6NGj/Pz8vvdewRA4AUBe7u7uBgYGJiYmfn5+TU1N5eXlkk2amprMpZiTk1NSUlJDQ0NKSkofdjFz5sz6+vqtW7cOXK//rampqbS01M7OrqcCbm5uQUFBZWVlW7Zs6bRJJBLFxsbOnTt38eLFAoFg3LhxBw4cqKmpOXjwoHSxbg9Rc3NzUlLSnDlz5s2bZ2hoGB4ezuVy+3Z8OnUpMDAwKSmpn+0MYMvMS0AmJiaRkZGFhYWVlZWzZ89eu3btsWPH5G/ZwcGBEFJQUNCnvisDAicAsMbj8QghksupTiZOnKijoyO5jak+qqqqaJru9nJTYvfu3WPGjElMTMzNzZVeX1hY2NjYOHHiRMmaSZMm8Xg8yU3pTqQP0d27d4VCobOzM7NJW1vb3Ny8/8cnNDR0xYoVlpaW/WxnAFtmnpiOHTvW3d3d2NhYIBDs3LlTIBBI/ryQp2XmC2Iu5dUTAicADDwtLa3q6mpV96Kz5uZm8uePe0/4fH5KSgpFUR9//LFIJJKsZ8ZI6OnpSRc2NDRsaGjodb/Mjd/w8HDqTw8ePJA9CKRXubm5BQUFy5Yt608jA96yhYUFIYR5gM3g8Xg2NjbFxcXyt6ytrU3+/LLUEwInAAywtra2Fy9eWFlZqbojnTG/yL0OsXdzcwsODi4qKtq1a5dkpaGhISGkU5iU82Myb8HExcXRUq5cudKHjyCRnJx84cIFDofDRGJmF5GRkRRF9fPpaX9a1tPTc3BwYLLJSrS3tzMjfORsubW1lfz5ZaknBE4AGGA5OTk0TU+ePJlZ1NTU7OmmrpKZmppSFCXP+NRdu3Y5OjrevHlTssbZ2VlPT0/69/3atWutra2vvfZar62NGDGCz+fn5eX1rdvdSklJkQ7DzPV9WFgYTdPS95OV37Kvr+/NmzdLSkqYRaFQ+ODBA2Z0ipwtM1+QmZlZfz6FQiFwAsAA6OjoqK2tbW9vv3XrVmBgoLW19dKlS5lN9vb2z58/z8zMbGtrq66ufvDggXRFY2Pjx48fl5WVNTQ0tLW1ZWdnK244io6Ojq2tbUVFRa8lmRu2Ghoa0ms2bNjw9ddfHzlypL6+vqCgYNWqVRYWFv7+/vK09tFHHx0/fjwpKam+vl4sFldUVDx58oQQ4ufnZ2Zmpogp/VTVcnBwsI2NzdKlS8vLy589e7Z582aRSNT1ZSsZmC9I9khQ1ULgBIDO9u3bN2nSJELI5s2bfXx8kpKS4uLiCCHjx48vKSn54osvNmzYQAh59913i4qKmCrNzc3jxo3T1tb28PAYPXr0jz/+KHmUuHr16jfffHPhwoVjxozZtWsXcwvOzc2NGa+yatUqU1NTJyenGTNmPH/+XNEfbebMmYWFhZKHl9988429vX1xcfGkSZPWrVsnXXLy5MnBwcHSa7Zv3x4VFRURETF8+PBp06aNHDkyJydHV1eXENLrIYqPjw8KCoqJiRk2bJiFhUVgYGBtbS0hpLW1taqqqtu5dQghV69enTp16iuvvHLt2rX8/HwLC4spU6ZcvHhRnk+qqpaNjIwuXbpkZWXl4uJiaWn5yy+/nDlzpteRndKuX79uaWk5fvx4+asoG610hJC0tDTl7xdgaGLG2it0F/7+/sbGxgrdhTzk+W0pKirS1NQ8fPiwcrrUK7FY7OHhkZycjJYZNTU1fD5/79698hRWwrndLVxxAsAAGBRJLQgh9vb2ERERERER3U47rmRisTgzM7OhocHPzw8tM3bs2OHi4hIQEKCIxgcKAqdS7d27l3k94cCBA8yaAUzeFBER4eTkZGBgoKWlZW9v//e//72nn4Zly5bp6+tTFMXqbQV5MhB1Ip2zqach7bGxsRRFcTgcR0dHOe8Uyd4RRVFcLtfS0nLRokW///573xqUpqpvrdOHoiiKx+OZmpp6enru2bOHudEHfRASEjJ//nw/Pz/lzGIvQ05OzsmTJ7Ozs2UPLR0iLRNCYmNj8/Lyzp49y+VyB7zxgaT8i1wytG/VMg889u/fzyyePn3awMDg1KlT/W952rRpiYmJz549q6+vT0tL43K57777bk+FmVk0b968KWfj9+7dmzJlCiFkwoQJbDvGTNRibm7e2traaVN7e7uNjQ0hxMvLi22z3e5IIBDQNN3Y2Hjq1Clra2s9Pb0//vij/y2r8FuTfCjm7Zsff/xx6dKlFEVZWFhcv35dnl0o+nZWSEgIM9h/5MiRJ06cUNyOesXqt+W7777bvHmzQvsDrGRmZkZFRbW3t8tfRVW3ahE4la3TT/AAmjlzpvQ5x0wQWl5e3m1hVoEzLy9v7ty5R44ccXFx6VvgZF7ZT09P77QpLS2NuYQd2MDJ+Oabbwgha9as6X/LKvzWOn0oxokTJzgcjqmp6YsXL3rdhap+XJRviP+2DEF4xgms0TR94sQJyVxWp0+fln57fvjw4YSQnmYnoShK/h3Jk4FIttWrVxNC9u/f32l9bGws8/KhIrz++uuEELbZBBWtP9+axPvvv7906dKqqirJ3WMAUBp1DJzx8fG6urocDue1114zMzPjcrm6urqurq4eHh7MOGJDQ8O///3vkvKXLl1ycnISCAR8Pn/cuHHfffcdIeQf//iHnp4eRVFGRkaZmZm//vqrjY2NhoaGPJP9y06TRGRmF+p1qzRWyZsIIWKxOCoqasyYMdra2sOHDx81alRUVJR06glpjx490tbWHjVqlKRXe/bsGTNmjJaWlkAg2LRpU6/HQU7y5IF66623Xn311R9//FE64fvPP/8sFAqnT5/eqfBAfaHt7e1Ean61wfitycCMkszOzu61JAAMMOVf5BI5bqds376dEHLt2rWmpqaampp3332XEHLmzJnq6uqmpibmhau8vDym8IkTJ3bs2PH8+fNnz55Nnjx52LBhzPo7d+7o6Oj87W9/YxZDQkIOHTokZyf9/f11dXXv3LnT3NxcWFg4adIkfX19yQ20bdu28Xi8w4cPv3jx4tatW66ursOHD3/69Kk8Wzvd9GOGsn3++efMYlhYGCHkwoULdXV1VVVVHh4eurq6kkeDkZGRGhoaWVlZQqHwt99+MzMz8/T07Lb/TU1N+vr6AQEBkjVhYWEURX322We1tbVCoTAxMZGwecbJeOONN7reqj19+rS+vn5ERERPtezs7EpLS//3f/+XEBIYGChZP2fOnJSUFGYOM+lbtX3+Qjvd1Tx8+DAhZNOmTcziYPzWun4oifr6ekLIiBEjum1KGm7VwssKzzj/AxM4GxoamMV//vOfhJCCggJm8ZdffiGEpKamdq0YFRVF/syBQNP0//3f/xFCjhw5cuzYseDgYPk76e/vL/1rdf36dULIzp07aZoWCoV6enp+fn6SrUx/mMgheyst30+wSCRiFpnwdv/+fWZx0qRJr7/+uqTlFStWcDiclpaWrv0PCwsbPXp0fX09sygUCnV0dN555x1JAbYvBzG6DZy9YgLnixcvdHV1jYyMhEIhTdPFxcVWVlYtLS1dA6c0Vl+o9MtBGRkZZmZmpqamFRUV9OD81jp9qK4oijI0NOx2kzQETnhZqerc1lTMdewAY97ZY+68EUKYN5W7nf2S2SQZUrZixYoffvhh5cqVb7/9dkZGRp87IJ0mSXZ2Iba5h2TrlLypubmZz+dLtorFYi6XK/2EjPH111+np6d///33+vr6zJr79+8LhUIvL68+9GGgCASCDz744IsvvkhNTf3oo4/i4uJWr17N4/GYCZ17wvYLrauroyhKQ0PD3Nx8xowZ27dvZxIYDcZvTbampiaapg0MDOTs1fz58+UsOajFxcWdOHFC1b0AJZFn9kRFUMdnnGydOXPG09PTxMRES0tL+tknIzIysrGxsaqqqp97kaRJkp1dqD+5h3o1Y8aM3377LSsrSyQS/frrr5mZmX/96187/QSnpqZGR0fn5OSMHDlSspI5vZhcBCrEvCJ04MCBFy9enDhxYuXKld0W688Xylyctbe3V1RUfPnll8xYFzI4vzXZ7t27RwhxdHTsfw8BgJXBccUpQ3l5+Zw5c+bOnfvll1++8sorn3/+ufRPbVtb2/r165lXN3fv3s3cAe4D6TRJsrML9Sf3UK927Njx22+/LV26tLGx0cLCYsGCBZ1eyfn888+/++67f/3rX51iAHPF09LS0v8+9IeLi8vkyZOvXr3q7+8/f/58IyOjrmUU9IUOxm9NtnPnzhFC3nvvPTnLD4XrMIqigoKCenrxCl4+6enpvr6+yt/voA+cBQUFbW1tq1evtrW1JV1GWaxbt2758uVz58599OjRrl27pk+f7ubm1oe9SKdJkp1dqD+5h3pVWFhYXFxcXV2tqdn5i6NpesuWLbW1tZmZmV23Ojs7czicn376adWqVf3vRn+sXr366tWrGRkZksnBO1HQFzoYvzUZnj59GhcXZ2Vl9fHHH/e/hwDAyqC/VWttbU0IOX/+fHNzc1FRkfRDqcTEREtLy7lz5xJCoqKinJycFi1axLyLKI+e0iTJzi7Un9xDvVq7dq21tXW3E+nduXPn008//eKLL7hcrvQkbXv37iWEmJiYzJs3LyMjIzk5ub6+/tatW5JxhP3HKg/UggULhg8fPmfOHCYudqWgL3QwfmsSNE03NjZ2dHTQNF1dXZ2WljZlyhQNDY3MzEz5n3ECwIBR/vtIpLc33+Lj45lZEEeOHHnp0qXo6Ggme7iZmdnRo0dTU1OZBKdGRkbHjx+naXrz5s3GxsaGhobz589nhtbZ2dm5uLhQFGVsbHz58mWapoOCgjgcDiFEIBD8+uuvvXbS39+fme9UU1PTwMBg9uzZxcXFkq0dHR179uxxcHDgcrlGRkZz5sy5e/euPFs/++wzpvO6urpz5879/PPPzc3NCSE6Ojre3t6JiYnMB3dwcCguLj548CDzs2hjY3Pv3j2apv/1r38NGzZM8t1xudxXX3315MmTNE0XFBR0+/3u2bOH2XVDQ8OyZcuGDRump6c3derUbdu2EUKsrKzy8/N7PRpXrlyZMmWKhYUF06a5ubm7u/tPP/3EbD179qy+vv7u3bu7Vvz666+Z+faGDx++du1aZuXf//535kuhaTo8PJw5AhwOx8nJ6dKlS337Qn/++efRo0cz3bOwsJg/f37Xzgy6b+3UqVPjx4/X0dHh8XjMh2Veo3399dcjIiKePXvW6xfHwFu18LLCcBT1oiZpkjpJTEyUHgfZ0tISFBSkpaXFDPAA9aTybw2BE15WGI6idtQtTdLTp08DAgKk85nweDxra+u2tra2tjYmOTCoG3xrAC+fQf+Msw/++OMPqmcKSjLXf9ra2lwuNzk5ubKysq2t7fHjx4cOHdq2bZufn19/HnQN0qMxWCjoWwNFO3/+fEhIiHRmtyVLlkgXmD59ur6+voaGxtixY2/cuKGSTnp6enb9Pyvnu9n9qUsIaWtri4qKsre35/F4hoaGzs7OZWVlXYs1Nzc7OjqGh4czi6dOnYqJiVG3a5K+UP5FLlH72ynqkyapk4sXL7799tsGBgYaGhoCgcDd3T0xMbGtrU3V/QJZVP6t4VYtW9u2bZs1a5ZkCic7OzvmKfXp06eli2VnZ/v4+PR/d302bdq0rj/p//3f/63oujRNz5kzZ8yYMVevXmX+HPT29pbM7CYtODiYEBIWFiZZEx8fP23atNraWjl3JBtu1aqRqKgoZqY3dePh4fHDDz+ouhfAzlD41kQikZeX1+XLl9Wqqb6Jjo5OTU3Nz8+Xnu8pISFhyZIl/v7+hYWFzLuK6oDP59fX10tPNbVy5Uo5h7H2p25qampmZmZ+fv64ceMIIRYWFllZWV2LXb58uWtuovXr15eUlMyYMePixYushmCplaF4qxYABlZycnL/J+ca8Kb64P79+1u3bt25c6d01CSEuLu7BwYGPnr0aOPGjarqW1fnzp2TjnwPHz68ffv2W2+9pei6+/fvd3V1ZaJmT0Qi0aZNm+Lj47tu2rFjR15eXrebBgsETgAgRGZitYCAAB6PxwzCIYSsWbNGV1eXoqiamhpCSGBg4IYNG4qLiymKsre3l52Vj1VTRL6kdQMoISGBpmlvb++um3bv3j169OhDhw6dP3++27oyDqA8uee2bdtmbW2tra09fvx45g4kW9HR0evXr+9DRVZ1W1tbr1696uLiIrtYWFjYmjVrup3m08jIaNq0afHx8TRN96Wv6kD5d4eJ2j/jBHiZyPkcSHZitUWLFpmZmUkK79mzhxBSXV3NLM6bN8/Ozk6yVXZWPlZN9Zq0Tlr/f1tsbW2dnJw6rWTS+9A0ffnyZQ6HM3LkyMbGRrrLM07ZB1B27rmNGzdqaWllZGTU1taGhoZyOJzr16+z6nlFRYWTk5NYLO7Dp2ZVt7S0lBDi4uLi6elpbm6upaXl6Oi4b98+ZoIORm5urre3N03TzPze0s84GSEhIYR9dqauVPWME1ecAEBEIlFsbOzcuXMXL14sEAjGjRt34MCBmpqaPs8wpampyVx7OTk5JSUlNTQ0pKSk9KGdmTNn1tfXb926tW/dYKWpqam0tJSZsqNbbm5uQUFBZWVlW7Zs6bRJzgPo7u5uYGBgYmLi5+fX1NRUXl5OCGlubk5KSpozZ868efMMDQ3Dw8O5XC7bwxUdHb1u3Tpmogy2WNVl5sAyMTGJjIwsLCysrKycPXv22rVrjx07xhQQiUSBgYFJSUkyGnFwcCCE9DQBiPpD4ASAAU6s1ol0Vj51xqR9ZeaB6snu3bvHjBmTmJiYm5srvZ7tAZTOPXf37l2hUOjs7Mxs0tbWNjc3Z3W4Hj9+fOrUKWZOULbY1tXS0iKEjB071t3d3djYWCAQ7Ny5UyAQSP5ECA0NXbFiBZPOryfMQa6srOxDh9UBAicAKDaxGpHKyqfOmpubyZ+BoSd8Pj8lJYWiqI8//lgkEknW9+cANjU1EULCw8Ml4ykfPHggFArl73lMTMzy5cs7vdCkoLrM1JvMM2kGj8ezsbEpLi4mhOTm5hYUFCxbtkx2I8zUH8wBH4wQOAFAsYnVpLPyqTPm17zX4flubm7BwcFFRUW7du2SrOzPAWTeoImLi5N+inblyhU5u/306dNjx44xyW7Z6kNdPT09BweHO3fuSK9sb29nRukkJydfuHCBw+EwfwEwHy0yMpKiKOnsQ0z6+sE7cxYCJwD0nlhNU1OTua/YB9JZ+frZlEKZmppSFFVXV9dryV27djk6Ot68eVOypj+Z6UaMGMHn86XnZWQlJiZm8eLFxsbGSqvr6+t78+bNkpISZlEoFD548IAZnZKSkiId/qVfDpK+j80cZCZ3wmCEwAkAvSdWs7e3f/78eWZmZltbW3V19YMHD6SrGxsbP378uKysrKGhgQmKPWXlY9sUq6R1/aSjo2Nra1tRUdFrSeaGrYaGhvSaPmem4/P5H3300fHjx5OSkurr68VicUVFxZMnTwghfn5+ZmZmMqb0q6ys/PLLL4OCgrpuUlzd4OBgGxubpUuXlpeXP3v2bPPmzSKRqOsLUzIwB1n2SFC1prwXeP9EMBwFQInkfGVfdtq1Z8+evfnmm3w+f9SoUevWrdu0aRMhxN7enhlkcuPGDRsbG21t7alTpz59+lR2Vj5WTclIWtdV/39bAgICuFyuJHFNt3nxJDZt2iQ9HEXGAew191xLS8vmzZutra01NTWZ7LmFhYU0Tc+ZM4cQsm3btp46HBwcvHjx4m43KbTuw4cPFy5caGRkpKWl9frrr2dnZ3dbrKfhKDNnzrS0tJQewdI3SCsGAAqh/B8XVWXl6/9vS1FRkaam5uHDhweqS/0kFos9PDySk5MHUd1e1dTU8Pn8vXv39r8pjOMEgJfHIM2AYW9vHxERERERwYxWVC2xWJyZmdnQ0NCHJEWqqiuPHTt2uLi4BAQEKKJx5UDgBAD4t5CQkPnz5/v5+cnzlpBC5eTknDx5Mjs7W/bQUrWq26vY2Ni8vLyzZ89yudwBb1xpEDgBYCCFhoampKTU1dWNGjUqIyND1d3pi8jIyICAgE8++US13fDy8jp69KhkXt9BUVe2rKyslpaWnJwcIyOjAW9cmQZrVhcAUE9qm5WPlenTp0+fPl3VvXjZ+Pj4+Pj4qLoXAwBXnAAAACwgcAIAALCAwAkAAMACAicAAAALCJwAAAAsUDRNK3uXFKXkPQIAwMtK+VFMBcNRmEmSAECGuLg4Qki3E3ADgGqp4IoTAHq1YMECQkh6erqqOwIAneEZJwAAAAsInAAAACwgcAIAALCAwAkAAMACAicAAAALCJwAAAAsIHACAACwgMAJAADAAgInAAAACwicAAAALCBwAgAAsIDACQAAwAICJwAAAAsInAAAACwgcAIAALCAwAkAAMACAicAAAALCJwAAAAsIHACAACwgMAJAADAAgInAAAACwicAAAALCBwAgAAsIDACQAAwAICJwAAAAsInAAAACwgcAIAALCAwAkAAMACAicAAAALCJwAAAAsIHACAACwgMAJAADAgqaqOwAAhBBy7dq1/Px8yWJJSQkh5ODBg5I1EyZMeOONN1TQMwD4TxRN06ruAwCQ06dPz5o1S0NDg8PhEEKY/5gURRFCOjo6xGLxt99++9e//lXFvQQABE4ANdHW1jZ8+PD6+vputxoYGFRXV/N4PCX3CgC6wjNOALXA5XIXLlzYbWiUsQkAlA+BE0BdLFy4sLW1tev6tra2Dz74QPn9AYBu4VYtgLro6Oh45ZVXKisrO603MTF5+vQp8+wTAFQO/xUB1AWHw1myZEmnW7I8Hm/p0qWImgDqA/8bAdRI17u1ra2tCxcuVFV/AKAr3KoFUC8ODg7379+XLNra2hYXF6uwPwDQCa44AdTL4sWLuVwu828ej/e3v/1Ntf0BgE5wxQmgXu7fv+/g4CBZvHv37ujRo1XYHwDoBFecAOrF3t5+woQJFEVRFDVhwgRETQB1g8AJoHY+/PBDDQ0NDQ2NDz/8UNV9AYDOcKsWQO08fvx4xIgRNE0/fPjQ0tJS1d0BgP+AwNkv8+fPV3UX4OWUk5NDCPH09FRxP+AldeLECVV3YRDDrdp+ycjIqKioUHUvQL1UVFRkZGT0sxFra2sbG5sB6Y/i4PwfjAbk/BzicMXZLxRFpaWlLViwQNUdATWSnp7u6+vbz/9Zz58/J4QYGxsPUKcUAuf/YDQg5+cQh0TWAOpIzUMmwFCGW7UAAAAsIHACAACwgMAJAADAAgInAAAACwicAGrh7NmzAoHg22+/VXVHFOX8+fMhISEnT560tbVlJhRcsmSJdIHp06fr6+traGiMHTv2xo0bKumkp6cn1YWenp6i6xJC2traoqKi7O3teTyeoaGhs7NzWVlZ12LNzc2Ojo7h4eHM4qlTp2JiYsRisZx7gQGBwAmgFl7u4QHbt29PSEgIDQ2dN29eSUmJnZ3dsGHDjhw5cubMGUmZ77///sSJE7NmzSosLHR1dVVhbzuZOnWqEur6+vp+9dVXR48eFQqFv//+u52dXWNjY9diYWFhd+/elSx6e3vz+XwvL68XL170uZPAFoajAKiFmTNn1tXVKWFHIpHIy8vr8uXLStgXIzo6OjU1NT8/n8/nS1YmJCQsWbLE39+/sLBQIBAorTOy8fn8+vp6fX19yZqVK1fKOVC1P3VTU1MzMzPz8/PHjRtHCLGwsMjKyupa7PLly7dv3+60cv369SUlJTNmzLh48aKmJn7SlQFXnABDS3JyclVVldJ2d//+/a1bt+7cuVM6ahJC3N3dAwMDHz16tHHjRqV1plfnzp2TjnwPHz68ffv2W2+9pei6+/fvd3V1ZaJmT0Qi0aZNm+Lj47tu2rFjR15eXrebQBEQOAFULzc319ramqKoffv2EUKSkpJ0dXV1dHSysrLee+89AwMDKyur48ePM4UTEhL4fL6pqenKlSstLCz4fL67u/u1a9eYrQEBATwez9zcnFlcs2aNrq4uRVE1NTWEkMDAwA0bNhQXF1MUZW9vTwg5d+6cgYFBZGSkgj5aQkICTdPe3t5dN+3evXv06NGHDh06f/58t3Vpmo6NjX311Ve1tLSMjIxmz579xx9/MJtkHyJCiFgs3rZtm7W1tba29vjx49PS0vrQ+ejo6PXr1/ehIqu6ra2tV69edXFxkV0sLCxszZo1JiYmXTcZGRlNmzYtPj7+5b7hr0Zo6AdCSFpamqp7AeqF+Y1mW+vhw4eEkM8//5xZDAsLI4RcuHChrq6uqqrKw8NDV1e3tbWV2erv76+rq3vnzp3m5ubCwsJJkybp6+uXl5czWxctWmRmZiZpec+ePYSQ6upqZnHevHl2dnaSradPn9bX14+IiOjDJ5Xn/Le1tXVycuq00s7OrrS0lKbpy5cvczickSNHNjY20jSdnZ3t4+MjKbZt2zYej3f48OEXL17cunXL1dV1+PDhT58+ZbbKPkQbN27U0tLKyMiora0NDQ3lcDjXr19n9ekqKiqcnJzEYjGrWn2oW1paSghxcXHx9PQ0NzfX0tJydHTct29fR0eHpExubq63tzdN09XV1YSQsLCwTo2EhIQQQm7evNnr7vp2foI0XHECqC93d3cDAwMTExM/P7+mpqby8nLJJk1NTeZSzMnJKSkpqaGhISUlpQ+7mDlzZn19/datWweu1//W1NRUWlpqZ2fXUwE3N7egoKCysrItW7Z02iQSiWJjY+fOnbt48WKBQDBu3LgDBw7U1NQcPHhQuli3h6i5uTkpKWnOnDnz5s0zNDQMDw/ncrlsj090dPS6des4nL78e9AdswAAIABJREFUSLKqy7wEZGJiEhkZWVhYWFlZOXv27LVr1x47dowpIBKJAgMDk5KSZDTi4OBACCkoKOhDb4EtBE6AQYDH4xFC2traut06ceJEHR0dyW1M9VFVVUXTtI6Ojowyu3fvHjNmTGJiYm5urvT6wsLCxsbGiRMnStZMmjSJx+NJbkp3In2I7t69KxQKnZ2dmU3a2trm5uasjs/jx49PnTq1dOlS+av0ua6WlhYhZOzYse7u7sbGxgKBYOfOnQKBQPInQmho6IoVK2RnZmUOcmVlZR86DGwhcAK8DLS0tJibeGqlubmZ/BkYesLn81NSUiiK+vjjj0UikWQ9M76i0zhIQ0PDhoaGXvfb1NRECAkPD5eMp3zw4IFQKJS/5zExMcuXL+/0QpOC6lpYWBBCmIfQDB6PZ2NjU1xcTAjJzc0tKChYtmyZ7Ea0tbXJnwccFA2BE2DQa2tre/HihZWVlao70hnza97r8Hw3N7fg4OCioqJdu3ZJVhoaGhJCOoVJOT8m8wZNXFyc9HOpK1euyNntp0+fHjt2bPXq1XKW72ddPT09BweHO3fuSK9sb29nRukkJydfuHCBw+EwfwEwHy0yMpKiqF9//VVSvrW1lfx5wEHREDgBBr2cnByapidPnswsampq9nRTV8lMTU0pipJnfOquXbscHR1v3rwpWePs7KynpycdG65du9ba2vraa6/12tqIESP4fH5eXl7fuh0TE7N48eK+ZXbrW11fX9+bN2+WlJQwi0Kh8MGDB8zolJSUFOnwL/1ykPR9bOYgm5mZ9aHPwBYCJ8Cg1NHRUVtb297efuvWrcDAQGtra8lDNXt7++fPn2dmZra1tVVXVz948EC6orGx8ePHj8vKyhoaGtra2rKzsxU3HEVHR8fW1raioqLXkswNWw0NDek1GzZs+Prrr48cOVJfX19QULBq1SoLCwt/f395Wvvoo4+OHz+elJRUX18vFosrKiqePHlCCPHz8zMzM5MxpV9lZeWXX34ZFBTUdZPi6gYHB9vY2CxdurS8vPzZs2ebN28WiURdX5iSgTnIskeCwkBB4ARQvX379k2aNIkQsnnzZh8fn6SkpLi4OELI+PHjS0pKvvjiiw0bNhBC3n333aKiIqZKc3PzuHHjtLW1PTw8Ro8e/eOPP0oeJa5evfrNN99cuHDhmDFjdu3axdy+c3NzY0a8rFq1ytTU1MnJacaMGc+fP1f0R5s5c2ZhYaHk4eU333xjb29fXFw8adKkdevWSZecPHlycHCw9Jrt27dHRUVFREQMHz582rRpI0eOzMnJ0dXVJYT0eoji4+ODgoJiYmKGDRtmYWERGBhYW1tLCGltba2qqup2Xh7Gp59+6u3tbW1t3XWT4uoaGRldunTJysrKxcXF0tLyl19+OXPmTK8jO6Vdv37d0tJy/Pjx8leBvlPeyJeXEcE4TuhCCePk/P39jY2NFboLechz/hcVFWlqah4+fFg5XeqVWCz28PBITk4eRHV7VVNTw+fz9+7dK09hjOPsP1xxAgxKgyUhhr29fURERERERLdTliuZWCzOzMxsaGjw8/MbLHXlsWPHDhcXl4CAAEU0Dl0hcAKAYoWEhMyfP9/Pz085s9jLkJOTc/LkyezsbNlDS9Wqbq9iY2Pz8vLOnj3L5XIHvHHoFgKnUi1btkxfX5+iqD6/76dWOjo64uLi3N3d5a8inY6RwePxTE1NPT099+zZwzyFAtlCQ0NTUlLq6upGjRqVkZGh6u7IJTIyMiAg4JNPPlFtN7y8vI4ePSqZyHdQ1JUtKyurpaUlJyfHyMhowBuHHqn6XvHgRtg/42TmoZZnSkk1d+/evSlTphBCJkyYwLaunZ2dQCCgaZp5NfTHH39cunQpRVEWFhZsJxRVQ0PnGVIfzn9QuaFzfioOrjjh/xOJRPJfO+bn52/ZsmXVqlWsXvzriqIoQ0NDT0/PlJSU9PT0yspKpaWlZIXVwQGAlxsCp7JRFKXqLnSPVZrGCRMmnDx5ctGiRbJnU2Pl/fffX7p0aVVV1YEDBwaqzYGi5ByWAKDOEDgVjqbpPXv2jBkzRktLSyAQbNq0SbLp008/1dHR0dfXr6qq2rBhg6Wl5d27d+mecxDKTsRIZOYvZJumsT/6nOKRGcKfnZ1NXt6DAwCDnkpvFA96RI5nPGFhYRRFffbZZ7W1tUKhMDExkUg942RyCq5fv/7zzz+fO3fu77//LjsHoexEjLLrskrTKKc33nij6zPOXlM8Sp5xdlJfX08IGTFixKA+OEPnGZI85z+om6FzfioODl+/9PrDIRQKdXR03nnnHcmaTi8HMbFBJBJJyuvp6fn5+UnK//LLL4QQSRDy9/eXDjnXr18nhOzcuVOeukoLnL3qKXDSNM089WT+PUgPztD5YULgHIyGzvmpOJpKu7Qdmu7fvy8UCr28vOQszzYHoXQiRrZ11VBTUxNN0wYGBt1uHVwHR20fZg8sX19fX19fVfcCQKkQOBWLmXmZyQQkjz7kIJQkYuxP/kI1ce/ePUKIo6Njt1sH18Fh/q5/ufn6+gYGBrq5uam6I8DClStX4uPjVd2LwQ2BU7GYZLYtLS1ylmebg1A6EWN/8heqiXPnzhFC3nvvvW63Dq6Ds2DBAgW1rD58fX3d3NyGwid9ySBw9hPeqlUsZ2dnDofz008/yV+eVQ5C6USMvdZVnzSN3Xr69GlcXJyVldXHH3/cbYGhfHAAQH0gcCqWiYnJvHnzMjIykpOT6+vrb926dfDgQRnl5clB2FMixl7rskrT2J9PLU+KR5qmGxsbOzo6aJqurq5OS0ubMmWKhoZGZmZmT884X46DAwCDnkpfTRr0iBxvFTY0NCxbtmzYsGF6enpTp07dtm0bIcTKyio/Pz8mJobJlThixAhJ3qWOjo49e/Y4ODhwuVwjI6M5c+Yw4xcZ/v7+XC7X0tJSU1PTwMBg9uzZxcXFkq2y6z579uzNN9/k8/mjRo1at24dM6LU3t6eGbBx48YNGxsbbW3tqVOnSgZp9OTKlStTpkyxsLBgziJzc3N3d/effvqJ2Xr27Fl9ff3du3d3rXjq1Knx48fr6OjweDwOh0P+nDzo9ddfj4iIePbsmaTk4D04Q+etRXnOf1A3Q+f8VByKpmlVxOuXBEVRaWlpynzGs3LlyhMnTjx79kxpexxE1OTgpKen+/r6DoX/Wco//6H/hs75qTi4VTv4DJZEjCqBgwMAiobACZ398ccfVM8UlIkXXnrnz58PCQmRziu3ZMkS6QLTp0/X19fX0NAYO3bsjRs3VNJJT0/Prud8p1FMiqhLCGlra4uKirK3t+fxeIaGhs7OzmVlZV2LNTc3Ozo6hoeHM4unTp2KiYnB34tKhsA5mCgnEaOjo6OMm/upqakK2m8/DcYslUPH9u3bExISQkND582bV1JSYmdnN2zYsCNHjpw5c0ZS5vvvvz9x4sSsWbMKCwtdXV1V2NtOpk6dqoS6vr6+X3311dGjR4VC4e+//25nZ9fY2Ni1WFhY2N27dyWL3t7efD7fy8uLGakMyoHAOZhERUW1tLTQNF1aWvr++++rujvqZUgdnAFMc6aEjGnR0dGpqanp6en6+vqSlQkJCRwOx9/fX62yyPH5/Pr6eum/FP39/f/+978rum5qampmZuaJEyfeeOMNTU1NCwuLrKwsZ2fnTsUuX758+/btTivXr18/YcKEGTNmtLe3y7Mv6D8EToDBZwDTnCk6Y9r9+/e3bt26c+dOZjIQCXd398DAwEePHm3cuFFxe2fr3Llz0tH94cOHt2/ffuuttxRdd//+/a6uruPGjZNRRiQSbdq0qdu5C3bs2JGXl4dpDZQGgRNANegBSnMmO58a24xpfU4J15OEhASapr29vbtu2r179+jRow8dOnT+/Hm2hygpKUlXV1dHRycrK+u9994zMDCwsrJiMigwxGLxtm3brK2ttbW1x48f37cZEKOjo9evX9+Hiqzqtra2Xr16tdec8GFhYWvWrOl2/k4jI6Np06bFx8fjXVklGcixLUMPwTg26ELOcXIDmOZMdj41Vk31mhJOmjznv62trZOTU6eVdnZ2paWlNE1fvnyZw+GMHDmysbGRpuns7GwfHx9JMdmHiEmec+HChbq6uqqqKg8PD11d3dbWVmbrxo0btbS0MjIyamtrQ0NDORzO9evX5flQEhUVFU5OTmKxmFWtPtQtLS0lhLi4uHh6epqbm2tpaTk6Ou7bt4+ZHoSRm5vr7e1N0zQz93JYWFinRkJCQohU2iUZMI6z/3DFCaACIpEoNjZ27ty5ixcvFggE48aNO3DgQE1NjeyJpWTQ1NRkrsycnJySkpIaGhpSUlL60M7MmTPr6+u3bt3at2500tTUVFpaamdn11MBNze3oKCgsrKyLVu2dNok5yFyd3c3MDAwMTHx8/NramoqLy8nhDQ3NyclJc2ZM2fevHmGhobh4eFcLpftAYmOjl63bh0zTQdbrOoyLwGZmJhERkYWFhZWVlbOnj177dq1x44dYwqIRKLAwMCkpCQZjTg4OBBCCgoK+tBbYAuBE0AFFJrmTDqfmmpVVVXRNK2joyOjzO7du8eMGZOYmJibmyu9nu0h4vF4hBBmQsS7d+8KhULJyzXa2trm5uasDsjjx49PnTrFzNfIFtu6WlpahJCxY8e6u7sbGxsLBIKdO3cKBALJnwihoaErVqywtLSU0QhzkCsrK/vQYWALgRNABRSd5kyST021mpubyZ+BoSd8Pj8lJYWiqI8//lgkEknW9+cQNTU1EULCw8Ml4ykfPHggFArl73lMTMzy5cs7vdCkoLrM1JXMU2cGj8ezsbEpLi4mhOTm5hYUFCxbtkx2I8z8lMwBB0VD4ARQAYWmOZPOp6ZazK95r8Pz3dzcgoODi4qKdu3aJVnZn0PEvEETFxcn/VzqypUrcnb76dOnx44dW716tZzl+1lXT0/PwcHhzp070ivb29sFAgEhJDk5+cKFCxwOh/kLgPlokZGRFEVJZ/tpbW0lfx5wUDQETgAVUGiaM+l8av1sqp9MTU0pipJnpOauXbscHR1v3rwpWcM2i5y0ESNG8Pn8vLy8vnU7JiZm8eLFxsbGSqvr6+t78+bNkpISZlEoFD548IAZnZKSkiId/qVfDpK+j80cZDMzsz70GdhC4ARQgQFPc9ZTPjW2TcmTEk5+Ojo6tra2FRUV8hyQlJQUDQ0N6TW9ZpGT0dpHH310/PjxpKSk+vp6sVhcUVHx5MkTQoifn5+ZmZmMKf0qKyu//PLLoKCgrpsUVzc4ONjGxmbp0qXl5eXPnj3bvHmzSCTq+sKUDMxBlj0SFAaM8l7gfRkRDEeBLuR83X8A05zJzqfGqikZKeG6kuf8DwgI4HK5QqGQWfz666+Zl2yHDx++du3aToU3bdokPRxFxiFKTExkXodxcHAoLi4+ePAgk8bVxsbm3r17NE23tLRs3rzZ2tpaU1OTSYtbWFhI0/ScOXMIIdu2beupw8HBwYsXL+52k0LrPnz4cOHChUZGRlpaWq+//np2dna3xXoajjJz5kxLS0vpESw9wXCU/sPh6xcETuhK+T9M/v7+xsbGytwjQ57zv6ioSFNTU5JRVeXEYrGHh0dycvIgqturmpoaPp+/d+9eeQojcPYfbtUCvAzUNj+Gvb19REREREREt1OWK5lYLM7MzGxoaOhDkh9V1ZXHjh07XFxcAgICFNE4dIXACQCKFRISMn/+fD8/P5XP556Tk3Py5Mns7GzZQ0vVqm6vYmNj8/Lyzp49y+VyB7xx6BYCJ8DgNijyqUVGRgYEBHzyySeq7YaXl9fRo0clM/cOirqyZWVltbS05OTkGBkZDXjj0BNNVXcAAPolKioqKipK1b3o3fTp06dPn67qXrxsfHx8fHx8VN2LIQdXnAAAACwgcAIAALCAwAkAAMACAicAAAALeDmov+SfORqGCOaUSE9PV3VHlAHn/6CDr6z/KJqmVd2HQYyiKFV3AQCANfzy9wcCJ4A6WrBgARkyl60AgwuecQIAALCAwAkAAMACAicAAAALCJwAAAAsIHACAACwgMAJAADAAgInAAAACwicAAAALCBwAgAAsIDACQAAwAICJwAAAAsInAAAACwgcAIAALCAwAkAAMACAicAAAALCJwAAAAsIHACAACwgMAJAADAAgInAAAACwicAAAALCBwAgAAsIDACQAAwAICJwAAAAsInAAAACwgcAIAALCAwAkAAMACAicAAAALCJwAAAAsIHACAACwgMAJAADAAgInAAAACwicAAAALCBwAgAAsEDRNK3qPgAAOXr0aHJyckdHB7NYWlpKCBk1ahSzyOFw/ud//mfRokUq6x8A/AmBE0At3Lp1a8KECTIK5Ofnjx8/Xmn9AYCeIHACqAtHR8e7d+92u8ne3r6oqEjJ/QGAbuEZJ4C6WLJkCZfL7bqey+V+9NFHyu8PAHQLV5wA6qKkpMTe3r7b/5JFRUX29vbK7xIAdIUrTgB1YWtr6+rqSlGU9EqKoiZOnIioCaA+EDgB1MiHH36ooaEhvUZDQ+PDDz9UVX8AoCvcqgVQI1VVVRYWFpJBKYQQDofz+PFjMzMzFfYKAKThihNAjZiamk6bNk1y0amhoeHp6YmoCaBWEDgB1MuSJUuk7wMtWbJEhZ0BgK5wqxZAvdTX15uYmLS2thJCuFxuVVWVoaGhqjsFAP+GK04A9WJgYPDuu+9qampqamrOmDEDURNA3SBwAqidxYsXi8VisViMyWkB1BBu1QKonebm5uHDh9M0XVNTo62treruAMB/QOBUC53GvAMAdAu/2OpAU9UdgP8vMDDQzc1N1b0Y0q5cuRIfH5+WlqbqjhBCSF5eHkVRsvOl9Jmvry/Ot0GHOT9V3QsgBFecaoKiqLS0tAULFqi6I0Naenq6r6+vmvyPaG9vJ4RoairkT1ucb4ORWp2fQxyuOAHUkYJCJgD0H96qBQAAYAGBEwAAgAUETgAAABYQOAEAAFhA4ATol7NnzwoEgm+//VbVHVGU8+fPh4SEnDx50tbWlqIoiqI6zTs/ffp0fX19DQ2NsWPH3rhxQyWd9PT0pLrQ09NTdF1CSFtbW1RUlL29PY/HMzQ0dHZ2Lisr61qsubnZ0dExPDycWTx16lRMTIxYLJZzL6BWEDgB+uXlHh6wffv2hISE0NDQefPmlZSU2NnZDRs27MiRI2fOnJGU+f7770+cODFr1qzCwkJXV1cV9raTqVOnKqGur6/vV199dfToUaFQ+Pvvv9vZ2TU2NnYtFhYWdvfuXcmit7c3n8/38vJ68eJFnzsJqoJX3gH6ZebMmXV1dUrYkUgk8vLyunz5shL2xYiOjk5NTc3Pz+fz+ZKVCQkJS5Ys8ff3LywsFAgESuuMbHw+v76+Xl9fX7Jm5cqVcg5U7U/d1NTUzMzM/Pz8cePGEUIsLCyysrK6Frt8+fLt27c7rVy/fn1JScmMGTMuXryI0UeDC644AQaH5OTkqqoqpe3u/v37W7du3blzp3TUJIS4u7sHBgY+evRo48aNSutMr86dOycd+R4+fHj79u233npL0XX379/v6urKRM2eiESiTZs2dTvpz44dO/Ly8jAf0KCDwAnQd7m5udbW1hRF7du3jxCSlJSkq6uro6OTlZX13nvvGRgYWFlZHT9+nCmckJDA5/NNTU1XrlxpYWHB5/Pd3d2vXbvGbA0ICODxeObm5szimjVrdHV1KYqqqakhhAQGBm7YsKG4uJiiKHt7e0LIuXPnDAwMIiMjFfTREhISaJr29vbuumn37t2jR48+dOjQ+fPnu61L03RsbOyrr76qpaVlZGQ0e/bsP/74g9kk+xARQsRi8bZt26ytrbW1tcePH9+3GRCjo6PXr1/fh4qs6ra2tl69etXFxUV2sbCwsDVr1piYmHTdZGRkNG3atPj4+Jf7hv9LiAY1QAhJS0tTdS+GOuY3mm2thw8fEkI+//xzZjEsLIwQcuHChbq6uqqqKg8PD11d3dbWVmarv7+/rq7unTt3mpubCwsLJ02apK+vX15ezmxdtGiRmZmZpOU9e/YQQqqrq5nFefPm2dnZSbaePn1aX18/IiKiD59UnvPN1tbWycmp00o7O7vS0lKapi9fvszhcEaOHNnY2EjTdHZ2to+Pj6TYtm3beDze4cOHX7x4cevWLVdX1+HDhz99+pTZKvsQbdy4UUtLKyMjo7a2NjQ0lMPhXL9+ndWnq6iocHJyEovFrGr1oW5paSkhxMXFxdPT09zcXEtLy9HRcd++fR0dHZIyubm53t7eNE1XV1cTQsLCwjo1EhISQgi5efNmr7vr2/kJioArToCB5+7ubmBgYGJi4ufn19TUVF5eLtmkqanJXIo5OTklJSU1NDSkpKT0YRczZ86sr6/funXrwPX635qamkpLS+3s7Hoq4ObmFhQUVFZWtmXLlk6bRCJRbGzs3LlzFy9eLBAIxo0bd+DAgZqamoMHD0oX6/YQNTc3JyUlzZkzZ968eYaGhuHh4Vwul+3xiY6OXrduHYfTlx83VnWZl4BMTEwiIyMLCwsrKytnz569du3aY8eOMQVEIlFgYGBSUpKMRhwcHAghBQUFfegtqAoCJ4AC8Xg8QkhbW1u3WydOnKijoyO5jak+qqqqaJrW0dGRUWb37t1jxoxJTEzMzc2VXl9YWNjY2Dhx4kTJmkmTJvF4PMlN6U6kD9Hdu3eFQqGzszOzSVtb29zcnNXxefz48alTp5YuXSp/lT7X1dLSIoSMHTvW3d3d2NhYIBDs3LlTIBBI/kQIDQ1dsWKFpaWljEaYg1xZWdmHDoOqIHACqJKWlhZzE0+tNDc3kz8DQ0/4fH5KSgpFUR9//LFIJJKsZ8ZXdBoHaWho2NDQ0Ot+m5qaCCHh4eGS8ZQPHjwQCoXy9zwmJmb58uWdXmhSUF0LCwtCCPMQmsHj8WxsbIqLiwkhubm5BQUFy5Ytk90Ik6icOeAwWCBwAqhMW1vbixcvrKysVN2Rzphf816H57u5uQUHBxcVFe3atUuy0tDQkBDSKUzK+TGZN2ji4uKknydduXJFzm4/ffr02LFjq1evlrN8P+vq6ek5ODjcuXNHemV7ezszSic5OfnChQscDof5C4D5aJGRkRRF/frrr5Lyra2t5M8DDoMFAieAyuTk5NA0PXnyZGZRU1Ozp5u6SmZqakpRlDzjU3ft2uXo6Hjz5k3JGmdnZz09PenYcO3atdbW1tdee63X1kaMGMHn8/Py8vrW7ZiYmMWLFxsbGyutrq+v782bN0tKSphFoVD44MEDZnRKSkqKdPiXfjlI+j42c5DNzMz60GdQFQROAKXq6Oiora1tb2+/detWYGCgtbW15KGavb398+fPMzMz29raqqurHzx4IF3R2Nj48ePHZWVlDQ0NbW1t2dnZihuOoqOjY2trW1FR0WtJ5oathoaG9JoNGzZ8/fXXR44cqa+vLygoWLVqlYWFhb+/vzytffTRR8ePH09KSqqvrxeLxRUVFU+ePCGE+Pn5mZmZyZjSr7Ky8ssvvwwKCuq6SXF1g4ODbWxsli5dWl5e/uzZs82bN4tEoq4vTMnAHGTZI0FB3SBwAvTdvn37Jk2aRAjZvHmzj49PUlJSXFwcIWT8+PElJSVffPHFhg0bCCHvvvtuUVERU6W5uXncuHHa2toeHh6jR4/+8ccfJY8SV69e/eabby5cuHDMmDG7du1ibt+5ubkxI15WrVplamrq5OQ0Y8aM58+fK/qjzZw5s7CwUPLw8ptvvrG3ty8uLp40adK6deukS06ePDk4OFh6zfbt26OioiIiIoYPHz5t2rSRI0fm5OTo6uoSQno9RPHx8UFBQTExMcOGDbOwsAgMDKytrSWEtLa2VlVVdTsvD+PTTz/19va2trbuuklxdY2MjC5dumRlZeXi4mJpafnLL7+cOXOm15Gd0q5fv25paTl+/Hj5q4DqKW/kC/SMYBynGlDCODl/f39jY2OF7kIe8pxvRUVFmpqahw8fVk6XeiUWiz08PJKTkwdR3V7V1NTw+fy9e/fKUxjjONUHrjgBlGqwJMSwt7ePiIiIiIjodspyJROLxZmZmQ0NDX5+foOlrjx27Njh4uISEBCgiMZBcRA4B5OWlpb169ebm5vr6Oi8/fbbzBscBw4cUHW//oN0/qlORo4cSQjZu3evevYcOgkJCZk/f76fn59yZrGXIScn5+TJk9nZ2bKHlqpV3V7Fxsbm5eWdPXuWy+UOeOOgUAicg8lnn3127ty5P/74Iz4+fuXKlcpMlCE/Sf4pgUDA3NZob28XCoWVlZXMr8/GjRvVs+eKFhoampKSUldXN2rUqIyMDFV3Ry6RkZEBAQGffPKJarvh5eV19OhRyUS+g6KubFlZWS0tLTk5OUZGRgPeOCgaAudgkpmZOXHiRENDwxUrVrz//vty1hKJRO7u7j0tKoGGhoa2trapqeno0aNZVVR5zwdWVFRUS0sLTdOlpaXyf30qN3369OjoaFX34mXj4+MTEhIi/TYyDCIInINJRUVFH+7qdEpHpeTsVNIyMzNZlVefngMASCBwDg4//PCDvb39kydP/vnPf1IU1Wk+M8alS5ecnJwEAgGfzx83btx3331HuqSj6pqdqtssTr3mfhrYnFbK7DkAQD8hcA4O77zzzv37983MzP72t7/RNN3ti46VlZW+vr5lZWWPHz/W09NbtGgRISQ+Pn7WrFlMOqr79+93WiSEbNmy5dNPP42Li3vy5MmsWbM++OCDX3/9dfXq1UFBQSKRSF9fPy0trbi42NbWdvny5ZJ5bZhXQzs6OuTs/7/+9a+9e/f2tFWZPQcA6CcEzpfH+++/v337diMjI2NjY29v72fPnvU6e3ivWZx6So8lT06ruro6yfu0Xl5eatJzAIB+0lR1B0AhmEehvQ4ZlD+Lk+z0WN0SCARMogxCSE5OjvTmc7f9AAAgAElEQVTkperc8/T0dDlLDmryz5wOagJfmfpA4Hx5nDlzZs+ePYWFhfX19XLGCUkWp/DwcMlKJlnSwPL09PT09Oxpq1r13NfXt/+NqL/4+Pj4+HhV9wJgUMKt2pdEeXn5nDlzzM3Nr127VldXFxMTI0+tfmZxGhDq1nMlzNelcgRTPA5CzOtvoA5wxfmSKCgoaGtrW716ta2tLSGEoih5avUzi9OAGLw9B4ChCVecLwkmscP58+ebm5uLioquXbsm2dQpHZX0ooaGRk9ZnGQbwJxWSu45AEB/qfr2A9C0HLfOysrK/vKXvxBCNDU1XV1dMzIyPvvsMyb5ra6u7ty5c2ma3rx5s7GxsaGh4fz58/ft20cIsbOzKy8vv3Hjho2Njba29tSpU58+fdppsaWlZfPmzdbW1pqamiYmJvPmzSssLExMTGSmx3NwcCguLj548KCBgQEhxMbG5t69ezRNnz17Vl9ff/fu3V27+vPPP0tmCDI3N/fy8upUQLU9l2HoZJ/o9XwDNTR0zk/1R9E0rfRgDZ1RFJWWlrZgwQJVd2RIS09P9/X1HQr/I3C+DUZD5/xUf7hVCwAAwAICJwAAAAsInADQd+fPnw8JCZFOwrpkyRLpAtOnT9fX19fQ0Bg7duyNGzdU0smYmBhHR0dtbW1dXV1HR8etW7fW19d3KtPR0REXF9c1/U6vddva2qKiouzt7Xk8nqGhobOzc1lZGSHk1KlTMTExgyVvObCj4mesQNM0XtZQD0Pn5YuBOt+2bds2a9as+vp6ZtHOzm7YsGGEkNOnT0sXy87O9vHx6f/u+mzmzJl79+6tqqpqaGhIT0/ncrnvvPOOdIF79+5NmTKFEDJhwgS2defMmTNmzJirV6+2tbU9fvzY29u7oKCA2RQfHz9t2rTa2toB+RRD5/xUf7jiBFCeAUwpqvLspNHR0ampqenp6fr6+pKVCQkJHA7H39+/rq5OhX3rhMfjrVmzxsTERE9Pb/78+bNnz/7hhx8kg5fy8/O3bNmyatUqFxcXtnVTU1MzMzNPnDjxxhtvaGpqWlhYZGVlSWaCXL9+/YQJE2bMmNHe3q6cTwrKgcAJoDwDmFJUtdlJ79+/v3Xr1p07d/L5fOn17u7ugYGBjx492rhxo6r61tXXX38t3U9LS0tCiCTF0IQJE06ePLlo0SItLS22dffv3+/q6jpu3Liedr1jx468vDzMbviSQeAEYIem6djY2FdffVVLS8vIyGj27NmSyeUDAgJ4PJ65uTmzuGbNGl1dXYqiampqSJcMowkJCXw+39TUdOXKlRYWFnw+393dXTL/A6umyEBnSO1VQkICTdPe3t5dN+3evXv06NGHDh06f/58t3VlHMBe06l2m4SVraKiIkNDQxsbm37WbW1tvXr1arfXqRJGRkbTpk2Lj4+nMYzkZaLaO8XAIHjGqQbkfIa0bds2Ho93+PDhFy9e3Lp1y9XVdfjw4U+fPmW2Llq0yMzMTFJ4z549hJDq6mpmcd68eUxKUYa/v7+uru6dO3eam5sLCwsnTZqkr69fXl7eh6ZOnz6tr68fEREhzyft//lma2vr5OTUaaWdnV1paSlN05cvX+ZwOCNHjmxsbKS7POOUfQDDwsIIIRcu/D/27jwsiivdH/hp6I1maUBBiQgCjaKAInEB1BEfb0iUUcQN3BLi1QdNDCLqIO6yuWWQB4V4XR5m4saiDhgV4+M4OOONGjOCmjZRQNk0yqLI0o0NdP3+qF/69rTQdIF0Nfj9/GVVnap6+9jwUss5799fv35dVVU1adIkU1NThUJBb123bp1AIDh9+vSrV682btxoZGR0+/ZtHWNWKBSVlZX79+8XCATHjh17u8H48ePffsapZd8nT54QQry8vPz9/QcOHCgQCNzc3A4cOKBUKtX3jYmJIYQUFBToGGdH8IzTcOCKE4ABuVyelJQ0e/bsxYsXi8ViT0/PgwcP1tTUHDp0qGsH5HK59LXXiBEj0tLSGhoa1KuK6k6XCqnvSlNT05MnT1xcXDpq4Ovru2bNmtLS0g0bNmhs0rED2y2n2mkRVu0GDx5sb2+/ffv2PXv2MK2B0+6+9A1bGxubhIQEqVT64sWLWbNmrVq16uTJk+r7urq6EkLu37/P6IxgyJA4ARiQSqWNjY1jxoxRrRk7diyfz1efYrfLxowZIxKJ2q0qalCqqqooiqKnNuxIfHz8sGHDUlNTr1+/rr6eaQeql1PVvQhruyoqKqqqqk6ePPnXv/519OjRjJ4Qt7sv/UzU3d3dz8/P2tpaLBbv2LFDLBZr/BFAd9SLFy90Px0YOCROAAbo0txmZmbqKy0tLRsaGt7J8QUCQXV19Ts5VM9pbm4mv6eNjgiFwvT0dA6Hs3TpUrlcrlrfnQ5UFWHl/K6srEwmk+kYNo/Hs7GxCQgIyMjIkEqliYmJOu7Y0b50/Vf6qTONz+c7OjqWlJSo72tiYkJ+7zToG5A4ARiwtLQkhGj8lq+rq7O3t+/+wVtaWt7VoXoUnQk6Hdrv6+sbFRVVVFQUFxenWtmdDnxXRVglEomxsbFUKmW6o8a+ZmZmrq6uDx48UG/Q2toqFovV1ygUCvJ7p0HfgMQJwICHh4eZmdlPP/2kWnPr1i2FQvHhhx/Si1wul76v2AX5+fkURfn4+HT/UD3K1taWw+HoMlIzLi7Ozc2toKBAtabTDtSia0VYa2trFy5cqL6mqKiora1t8ODB3d83JCSkoKDg8ePH9KJMJisrK9MYnUJ3FF0RCPoGJE4ABoRC4dq1a8+ePXv8+PH6+vr79++vXLnSzs4uPDycbiCRSF6+fJmTk9PS0lJdXV1WVqa+u0aFUUKIUql89epVa2vrvXv3IiMjHRwcwsLCunCod1ghtVMikcjZ2bmysrLTlvQNW2NjY/U12jtQ+9E6KsIaGho6YMCAdqf0MzU1vXz58tWrV+vr61taWgoKCj777DNTU9OoqKhOz9jpvlFRUY6OjmFhYeXl5bW1tdHR0XK5XOOVKLqjtIz1hN6HnZd54T8RDEcxADq+7q9UKvfu3evq6srj8aysrIKDgx8+fKjaWltbO2XKFKFQ6OTk9NVXX61fv54QIpFI6EEmGiVFw8PDeTzeoEGDuFyuhYXFrFmzSkpKunYoLRVS39b971tERASPx5PJZPTi2bNn6Zds+/fvv2rVKo3G69evVx+OoqUDOy2n2m4RVoqigoODCSFbt25tN9qZM2c6OTmZmZkJBAIXF5fQ0FDVrHgURd24cWPChAn0A0tCyMCBA/38/K5du6bLvhRFVVRULFiwwMrKSiAQjBs3Li8vT+PsgYGBgwYN0hij0gUYjmI48N9gEJA4DYH+fzGFh4dbW1vr84y07n/fioqKuFxuu6MhWdHW1jZp0qSjR4+yHYimmpoaoVD49ddfd/9QSJyGA7dqAdjUS6tnSCSS2NjY2NhY1eRzLGpra8vJyWloaAgNDWU7Fk3bt2/38vKKiIhgOxB4l5A4AaArYmJi5s2bFxoayvp87vn5+WfOnMnLy9M+tFT/kpKSCgsLL168yOPx2I4F3iUkTgB2bNy4MT09/fXr105OTqdPn2Y7nK5ISEiIiIjYuXMnu2FMnTr1xIkTqnl9DURubu6bN2/y8/OtrKzYjgXeMS7bAQC8pxITExmNwTdMAQEBAQEBbEdhiIKCgoKCgtiOAnoErjgBAAAYQOIEAABgAIkTAACAASROAAAABjgU6pIbAA6H4+PjY/ize/dtlZWVN2/enDt3LtuB9LjTp0/j+9br0N9P/MY2BEicBmHevHlshwCGhZ4YffTo0WwHAoYlOzub7RAAiRPAIM2fP58QkpWVxXYgAKAJzzgBAAAYQOIEAABgAIkTAACAASROAAAABpA4AQAAGEDiBAAAYACJEwAAgAEkTgAAAAaQOAEAABhA4gQAAGAAiRMAAIABJE4AAAAGkDgBAAAYQOIEAABgAIkTAACAASROAAAABpA4AQAAGEDiBAAAYACJEwAAgAEkTgAAAAaQOAEAABhA4gQAAGAAiRMAAIABJE4AAAAGkDgBAAAYQOIEAABgAIkTAACAASROAAAABpA4AQAAGEDiBAAAYACJEwAAgAEkTgAAAAa4bAcAAIQQIpPJ3rx5o1pUKBSEkFevXqnWCAQCkUjEQmQA8J84FEWxHQMAkLS0tC+//FJLg9TU1C+++EJv8QBAR5A4AQxCdXW1nZ1dW1tbu1uNjY1/++03GxsbPUcFAG/DM04Ag2BjYzN16lRjY+O3NxkbG//Xf/0XsiaAgUDiBDAUixcvbvcOEEVRixcv1n88ANAu3KoFMBQNDQ02NjbqrwjR+Hx+dXW1hYUFK1EBgAZccQIYCnNz8xkzZvB4PPWVXC43KCgIWRPAcCBxAhiQRYsWtba2qq9pa2tbtGgRW/EAwNtwqxbAgCgUiv79+zc0NKjWmJmZ1dTUCAQCFqMCAHW44gQwIHw+f968eXw+n17k8XghISHImgAGBYkTwLAsXLiQnjaIENLS0rJw4UJ24wEADbhVC2BYlErlwIEDq6urCSH9+/d//vx5u4M7AYAtuOIEMCxGRkYLFy7k8/k8Hm/RokXImgCGBokTwOAsWLBAoVDgPi2AYUJ1lF4mKyuL7RCgx1EU1a9fP0LIkydPSktL2Q4Hetz8+fPZDgEYwDPOXobD4bAdAgC8Y/g93LvgVm3vk5mZSYFeZGZmEkJYObVUKpVKpXo7Hb5XbKG/Y9C74FYtgCEaMWIE2yEAQPtwxQkAAMAAEicAAAADSJwAAAAMIHECAAAwgMQJAADAABInwDt28eJFsVj83XffsR1IT7ly5UpMTMyZM2ecnZ05HA6Hw1myZIl6g4CAAHNzc2NjY3d39zt37rAS5O7du93c3ExMTExNTd3c3LZs2VJfX6/RRqlU7tu3z8/Pj+m+LS0tiYmJEomEz+dbWlp6eHjQ81ScO3du9+7dbW1tPfnJgH1InADvGNWnB7Nv27YtJSVl48aNc+bMefz4sYuLS79+/Y4fP37hwgVVm8uXL2dnZ8+YMUMqlXp7e7MS57/+9a/ly5eXl5e/ePEiLi5u9+7dc+fOVW9QVFT0hz/8ISoqSiaTMd03JCTk22+/PXHihEwm++WXX1xcXBobGwkhM2fOFAqFU6dOraur6+kPCGxie/gvMEMwUF2PWJwAQRcymczX1/edHErH79XOnTuHDh0ql8tVa1xcXE6cOGFkZDRo0KC6ujrV+ry8vKCgoHcSW9cEBwerxzlv3jxCyLNnz+jFwsLC2bNnHz9+3MvLa9SoUYz2PXXqFIfDuXfvXkenjoiI8PX1bWlp0SVOA/+OQbtwxQnQWx09erSqqkpvpysuLt6yZcuOHTuEQqH6ej8/v8jIyKdPn65bt05vwXTq7Nmz6nEOGjSIEEJfFxJCRo0adebMmUWLFrVbJFz7vt988423t7enp2dHp96+fXthYWFycvK7+BxgiJA4Ad6l69evOzg4cDicAwcOEELS0tJMTU1FIlFubu60adMsLCzs7e1PnTpFN05JSREKhba2titWrLCzsxMKhX5+frdu3aK3RkRE8Pn8gQMH0otffvmlqakph8OpqakhhERGRq5du7akpITD4UgkEkLIpUuXLCwsEhISeuijpaSkUBQ1c+bMtzfFx8cPHTr0yJEjV65caXdfiqKSkpKGDx8uEAisrKxmzZr166+/0pu0dxEhpK2tbevWrQ4ODiYmJiNHjuzaHHVFRUWWlpaOjo7d3FehUNy8edPLy0tLeysrq8mTJycnJ1N9+qb9e43lK15giOBWrR517TZaRUUFIWT//v304qZNmwghf//731+/fl1VVTVp0iRTU1OFQkFvDQ8PNzU1ffDgQXNzs1QqHTt2rLm5eXl5Ob110aJFAwYMUB157969hJDq6mp6cc6cOS4uLqqt58+fNzc3j42N7cIn1eV75ezsPGLECI2VLi4uT548oSjqhx9+MDIyGjJkSGNjI/XWrdqtW7fy+fxjx47V1dXdu3fP29ubrtFNb9XeRevWrRMIBKdPn3716tXGjRuNjIxu376t4+dSKBSVlZX79+8XCATHjh17u8H48ePfvlWrZd8nT54QQry8vPz9/QcOHCgQCNzc3A4cOKBUKtX3jYmJIYQUFBR0GiFu1fZGuOIE0Ac/Pz8LCwsbG5vQ0NCmpqby8nLVJi6XS1+KjRgxIi0traGhIT09vQunCAwMrK+v37Jly7uL+v80NTU9efLExcWlowa+vr5r1qwpLS3dsGGDxia5XJ6UlDR79uzFixeLxWJPT8+DBw/W1NQcOnRIvVm7XdTc3JyWlhYcHDxnzhxLS8vNmzfzeDzd+2fw4MH29vbbt2/fs2dPSEgIo4/c7r70DVsbG5uEhASpVPrixYtZs2atWrXq5MmT6vu6uroSQu7fv8/ojNBbIHEC6BWfzyeEtLS0tLt1zJgxIpFIdRvTcFRVVVEUJRKJtLSJj48fNmxYamrq9evX1ddLpdLGxsYxY8ao1owdO5bP56tuSmtQ76KHDx/KZDIPDw96k4mJycCBA3Xvn4qKiqqqqpMnT/71r38dPXo0o0fC7e5LPxN1d3f38/OztrYWi8U7duwQi8UafwTQHfXixQvdTwe9CBIngGERCATV1dVsR6GpubmZ/J42OiIUCtPT0zkcztKlS+VyuWo9PTbDzMxMvbGlpWVDQ0On521qaiKEbN68mfO7srKytweQdITH49nY2AQEBGRkZEil0sTERB137GhfOzs7Qgj9mJnG5/MdHR1LSkrU9zUxMSG/dxr0PUicAAakpaWlrq7O3t6e7UA00Zmg06H9vr6+UVFRRUVFcXFxqpWWlpaEEI00qePHtLGxIYTs27dP/QnTjRs3mMYvkUiMjY2lUinTHTX2NTMzc3V1ffDggXqD1tZWsVisvkahUJDfOw36HiROAAOSn59PUZSPjw+9yOVyO7qpq2e2trYcDuf169edtoyLi3NzcysoKFCt8fDwMDMz++mnn1Rrbt26pVAoPvzww06PNnjwYKFQWFhYyCja2trahQsXqq8pKipqa2sbPHhw9/cNCQkpKCh4/PgxvSiTycrKyjRGp9AdNWDAAEZhQ2+BxAnAMqVS+erVq9bW1nv37kVGRjo4OISFhdGbJBLJy5cvc3JyWlpaqqury8rK1He0trZ+9uxZaWlpQ0NDS0tLXl5ezw1HEYlEzs7OlZWVnbakb9gaGxurr1m7du3Zs2ePHz9eX19///79lStX2tnZhYeH63K0zz///NSpU2lpafX19W1tbZWVlb/99hshJDQ0dMCAAe1O6Wdqanr58uWrV6/W19e3tLQUFBR89tlnpqamUVFRnZ6x032joqIcHR3DwsLKy8tra2ujo6PlcrnGK1F0R2kZ6wm9Gzsv80JXEQxH0aMuDBXYv38/PfJSJBLNnDkzNTWVfk/E1dW1pKTk0KFDFhYWhBBHR8dHjx5RFBUeHs7j8QYNGsTlci0sLGbNmlVSUqI6Wm1t7ZQpU4RCoZOT01dffbV+/XpCiEQiocer3Llzx9HR0cTEZOLEic+fP7948aK5uXl8fHwXPqku36uIiAgejyeTyejFs2fP0i/Z9u/ff9WqVRqN169frz4cRalU7t2719XVlcfjWVlZBQcHP3z4kN7UaRe9efMmOjrawcGBy+Xa2NjMmTNHKpVSFBUcHEwI2bp1a7vRzpw508nJyczMTCAQuLi4hIaG3r9/X7X1xo0bEyZMoB9YEkIGDhzo5+d37do1XfalKKqiomLBggVWVlYCgWDcuHF5eXkaZw8MDBw0aJDGGJV2YThKb4T/sF4GiVOf9PBLLTw83NraukdPoQtdvldFRUVcLrfd0ZCsaGtrmzRp0tGjR9kORFNNTY1QKPz66691aYzE2RvhVi0Ay3pLMQ2JRBIbGxsbG6uafI5FbW1tOTk5DQ0NoaGhbMeiafv27V5eXhEREWwHAj0FibOPW7Zsmbm5OYfDYfp6RQ9Rr0VF4/P5tra2/v7+e/fuffXqFdsBgjYxMTHz5s0LDQ3V5S2hHpWfn3/mzJm8vDztQ0v1LykpqbCw8OLFizwej+1YoKcgcfZxR44cOXz4MNtR/B9VLSqxWExRlFKprKqqysrKcnJyio6Odnd3V3/3ss/buHFjenr669evnZycTp8+zXY4OklISIiIiNi5cye7YUydOvXEiROqiXwNRG5u7ps3b/Lz862srNiOBXoQl+0A4L3G4XAsLS39/f39/f0DAwNDQkICAwMfPXqkMSqur0pMTGQ0JN9ABAQEBAQEsB2FIQoKCgoKCmI7CuhxuOLs+zgcDtsh6GTu3LlhYWFVVVUHDx5kOxYAgA4hcfZBFEXt3bt32LBhAoFALBbTYxhU2i3S1Glpp2vXro0bN04kEllYWHh6etbX13d0KNKN+lb0+MW8vDy9hQoAwBjbr/UCM0SHYQObNm3icDh//vOfX716JZPJUlNTiVqFo46KNGkp7dTY2GhhYbF79265XP78+fPZs2fTla06OlSn9a1Uzzg10Elu8ODBegtVu/dnqIAu3yvoCe/Pd6wvwX9YL9PpLziZTCYSiT766CPVGvpqjE6ccrlcJBKFhoaqGgsEgi+++IL6PRvJ5XJ6E51ui4uLKYr6+eefCSHnz59XP5GWQ3Wqo8RJURT91NNAQn1/fqkhcbLl/fmO9SV4OaivKS4ulslkU6dObXer7kWa1Es7OTs729raLl68ePXq1WFhYUOGDGF0KN01NTVRFEVPHGM4oc6bN687H6q32LdvX3Z2NttRvHd0mcUQDA2ecfY19M8hXVPibV0r0mRiYnL16tWJEycmJCQ4OzuHhobK5fJu1ntq16NHjwghbm5uhh8qALy3cMXZ1wiFQkLImzdv2t2qKtIUGRnJ6LDu7u7fffdddXV1UlLSrl273N3d6RlbunAoLS5dukQImTZtmkGF+j5ch3E4nDVr1syfP5/tQN47WVlZISEhbEcBzOCKs6/x8PAwMjK6du1au1u7VqTp2bNndAFCGxubnTt3ent7P3jwoGuH0uL58+f79u2zt7dfunSpgYcKAO8zJM6+hi4fcfr06aNHj9bX19+7d+/QoUOqrVqKNGnx7NmzFStW/PrrrwqFoqCgoKyszMfHR8uhdKlvRVFUY2MjXT6iuro6MzNzwoQJxsbGOTk59DNO/YQKAMAYyy8nAUNEh7cfGxoali1b1q9fPzMzs4kTJ27dupUQYm9vf/fuXaqDIk3aSzuVlpb6+flZWVkZGxt/8MEHmzZtam1t7ehQFEVpqW917ty5kSNHikQiPp9vZGREfp88aNy4cbGxsbW1teqN9RCqdu/PG4+6fK+gJ7w/37G+hENRFFs5G7qAw+FkZmbiWZR+0M+f3oefEXyv2PL+fMf6EtyqBQAAYACJEwC668qVKzExMeo145YsWaLeICAgwNzc3NjY2N3d/c6dO6wEGRsbO2LECAsLC4FAIJFI/vSnP6kXFo2Pj+f8J9XAX1pLS0tiYqJEIuHz+ZaWlh4eHqWlpYSQc+fO7d69u7cUVYV3AokTALpl27ZtKSkpGzduVNWM69ev3/Hjxy9cuKBqc/ny5ezs7BkzZkilUm9vb1bivHr16qpVq0pLS2tqahITE5OTkxlNbRESEvLtt9+eOHFCJpP98ssvLi4udN6dOXOmUCicOnVqXV1dj8UOhgWJE4BNcrncz8/P0A6lu127dmVkZGRlZZmbm6tWpqSkGBkZhYeHs17vWp2ZmVl4eLi1tbW5ufn8+fODg4MvXbpUUVGhanDs2DH1F0Do6RtpGRkZOTk52dnZ48eP53K5dnZ2ubm5qkvS1atXjxo1avr06a2trfr+VMAGJE4ANh09erSqqsrQDqWj4uLiLVu27Nixg552Q8XPzy8yMvLp06fr1q3TZzzanT9/3tjYWLXYv39/QoiOE0h988033t7enp6eHTXYvn17YWFhcnJy9+MEw4fECdBdFEUlJSUNHz5cIBBYWVnNmjVLNRFuREQEn88fOHAgvfjll1+amppyOJyamhpCSGRk5Nq1a0tKSjgcjkQiSUlJEQqFtra2K1assLOzEwqFfn5+t27d6sKhSDeKu+kuJSWFoqiZM2e+vSk+Pn7o0KFHjhy5cuVKu/tq6bROK8e9kyJxT58+NTExcXJy6rSlQqG4efOml5eXljZWVlaTJ09OTk7G+7HvBb0PgIFuIRhvp0c6jrHbunUrn88/duxYXV3dvXv3vL29+/fv//z5c3rrokWLBgwYoGq8d+9eQghd7IyiqDlz5ri4uKi2hoeHm5qaPnjwoLm5WSqVjh071tzcvLy8vAuH6rS4m7qufa+cnZ1HjBihsdLFxeXJkycURf3www9GRkZDhgxpbGykKCovLy8oKEjVTHunaakcR3W1SJy6pqYmc3PziIgI1Zq4uDh7e3tLS0sejzdkyJCgoKAff/yR3vTkyRNCiJeXl7+//8CBAwUCgZub24EDB+jpO1RiYmKIWv0+HWEcZ2+EK06AbpHL5UlJSbNnz168eLFYLPb09Dx48GBNTY36hE2McLlc+jpsxIgRaWlpDQ0N6enpXThOYGBgfX39li1buhZGp5qamp48eeLi4tJRA19f3zVr1pSWlm7YsEFjk46d5ufnZ2FhYWNjExoa2tTUVF5eTghpbm5OS0sLDg6eM2eOpaXl5s2beTwe0y5KTEy0s7OLj49Xrfnss8/OnTtXUVHR2Nh46tSp8vLyyZMnS6VSQgj9EpCNjU1CQoJUKn3x4sWsWbNWrVp18uRJ9WO6uroSQu7fv88oEuiNkDgBukUqlTY2No4ZM0a1ZuzYsXw+X3WLtTvGjBkjEom6Wayth1RVVVEURc/i1JH4+Phhw4alpqZev35dfT3TTlOvHNf9enZnz57Nysr6/vvv1V9oGjx48OjRo83MzPh8vo+PT3p6ulwup0u9CvIT6hIAACAASURBVAQCQoi7u7ufn5+1tbVYLN6xY4dYLNZI83RXvHjxQvdIoJdC4gToFnoQgpmZmfpKS0vLhoaGd3J8gUBQXV39Tg71bjU3N5Pfk0pHhEJheno6h8NZunSpXC5Xre9Op3WzSFxGRsauXbvy8/PpWq0d8fT0NDY2puvc2dnZEULoZ8k0Pp/v6OhYUlKivouJiQn5vVugb0PiBOgWS0tLQojGb/y6ujp7e/vuH7ylpeVdHeqdo/NEpwP/fX19o6KiioqK4uLiVCu702mqenPqz5xu3LihS8z79+8/fvz41atXP/jgA+0tlUqlUqmk/ywwMzNzdXWlq+6otLa2isVi9TUKhYL83i3QtyFxAnSLh4eHmZnZTz/9pFpz69YthULx4Ycf0otcLpe+x9gF+fn5FEX5+Ph0/1DvnK2tLYfD0WWkZlxcnJubW0FBgWpNp52mRdeKxFEUFR0dff/+/ZycHI0rXdrHH3+svki/beTr60svhoSEFBQUPH78mF6UyWRlZWUao1PorhgwYACjwKA3QuIE6BahULh27dqzZ88eP368vr7+/v37K1eutLOzCw8PpxtIJJKXL1/m5OS0tLRUV1eXlZWp725tbf3s2bPS0tKGhgY6KSqVylevXrW2tt67dy8yMtLBwSEsLKwLh9KluFt3iEQiZ2fnysrKTlvSN2zVx1B22mnaj9ZRkbjQ0NABAwa0O6XfgwcP9uzZc/jwYR6Ppz6v3tdff003ePr0aUZGRl1dXUtLy40bN5YtW+bg4LBy5Up6a1RUlKOjY1hYWHl5eW1tbXR0tFwu13jpie4KLWM9oe9g41Ve6DqC4Sh6pONQAaVSuXfvXldXVx6PZ2VlFRwc/PDhQ9XW2traKVOmCIVCJyenr776av369YQQiURCDzK5c+eOo6OjiYnJxIkTnz9/Hh4ezuPxBg0axOVyLSwsZs2aVVJS0rVDaSnu9raufa8iIiJ4PJ5MJqMXz549S79k279//1WrVmk0Xr9+vfpwFC2dpr1yHNVxkbjg4GBCyNatW98OtaOXXffu3Us3WLt2rYuLi6mpKZfLtbe3X758+bNnz9SPUFFRsWDBAisrK4FAMG7cuLy8PI1TBAYGDho0SGOMSqcwHKU3wn9YL4PEqU/6/6VGzwmnzzPSuva9Kioq4nK5GjPVsaitrW3SpElHjx7V/6lramqEQuHXX3/NdEckzt4It2oBDEsvqrMhkUhiY2NjY2PVy4ywpa2tLScnp6GhITQ0VP9n3759u5eXV0REhP5PDfqHxAkAXRcTEzNv3rzQ0FDW53PPz88/c+ZMXl6e9qGlPSEpKamwsPDixYs8Hk/PpwZWIHECGIqNGzemp6e/fv3aycnp9OnTbIejq4SEhIiIiJ07d7IbxtSpU0+cOKGay1dvcnNz37x5k5+fb2VlpedTA1u4bAcAAP9fYmJiYmIi21F0RUBAQEBAANtRsCMoKCgoKIjtKECvcMUJAADAABInAAAAA0icAAAADCBxAgAAMIDECQAAwACHoii2YwAGOBwO2yEAwDuG38O9C4aj9DL0BF3Q5+3bt48QsmbNGrYDAQBNuOIEMETz588nhGRlZbEdCABowjNOAAAABpA4AQAAGEDiBAAAYACJEwAAgAEkTgAAAAaQOAEAABhA4gQAAGAAiRMAAIABJE4AAAAGkDgBAAAYQOIEAABgAIkTAACAASROAAAABpA4AQAAGEDiBAAAYACJEwAAgAEkTgAAAAaQOAEAABhA4gQAAGAAiRMAAIABJE4AAAAGkDgBAAAYQOIEAABgAIkTAACAASROAAAABpA4AQAAGEDiBAAAYACJEwAAgAEkTgAAAAaQOAEAABhA4gQAAGAAiRMAAIABLtsBAAAhhNy6devu3buqxcePHxNCDh06pFozatSo8ePHsxAZAPwnDkVRbMcAAOT8+fMzZswwNjY2MjIihNA/mBwOhxCiVCrb2tq+++67P/7xjyxHCQBInAAGoqWlpX///vX19e1utbCwqK6u5vP5eo4KAN6GZ5wABoHH4y1YsKDd1KhlEwDoHxIngKFYsGCBQqF4e31LS8vChQv1Hw8AtAu3agEMhVKp/OCDD168eKGx3sbG5vnz5/SzTwBgHX4UAQyFkZHRkiVLNG7J8vn8sLAwZE0Aw4GfRgAD8vbdWoVCsWDBArbiAYC34VYtgGFxdXUtLi5WLTo7O5eUlLAYDwBowBUngGFZvHgxj8ej/83n8z/77DN24wEADbjiBDAsxcXFrq6uqsWHDx8OHTqUxXgAQAOuOAEMi0QiGTVqFIfD4XA4o0aNQtYEMDRInAAG59NPPzU2NjY2Nv7000/ZjgUANOFWLYDBefbs2eDBgymKqqioGDRoENvhAMB/QOLUn6SkpBs3brAdBfQO+fn5hBB/f3+W44BewtfXNyoqiu0o3he4Vas/N27cuHnzJttRgME5ffp0ZWWlxkoHBwdHR0dW4ukhN2/exPe/h9y8eRN/lOsT6nHqlY+PT3Z2NttRgGHhcDhr1qyZP3+++sqXL18SQqytrVkK6t2bN28eIQTf/55A9y3oDRIngCHqSykToI/BrVoAAAAGkDgBAAAYQOIEAABgAIkTAACAASROgF7p4sWLYrH4u+++YzuQnnLlypWYmJgzZ844OzvTExAuWbJEvUFAQIC5ubmxsbG7u/udO3dYCTI2NnbEiBEWFhYCgUAikfzpT39qbGxUbY2Pj+f8Jw8PD/XdW1paEhMTJRIJn8+3tLT08PAoLS0lhJw7d2737t1tbW16/jigIyROgF6pb09dsm3btpSUlI0bN86ZM+fx48cuLi79+vU7fvz4hQsXVG0uX76cnZ09Y8YMqVTq7e3NSpxXr15dtWpVaWlpTU1NYmJicnIyo5EhISEh33777YkTJ2Qy2S+//OLi4kLn3ZkzZwqFwqlTp9bV1fVY7NB1SJwAvVJgYODr169nzJjR0yeSy+V+fn49fRZ1u3btysjIyMrKMjc3V61MSUkxMjIKDw9//fq1PoPRzszMLDw83Nra2tzcfP78+cHBwZcuXaqoqFA1OHbsGKXm559/Vm3KyMjIycnJzs4eP348l8u1s7PLzc1VXZKuXr161KhR06dPb21t1fengs4gcQKANkePHq2qqtLb6YqLi7ds2bJjxw6hUKi+3s/PLzIy8unTp+vWrdNbMJ06f/68sbGxarF///6EEJlMpsu+33zzjbe3t6enZ0cNtm/fXlhYmJyc3P044d1C4gTofa5fv+7g4MDhcA4cOEAISUtLMzU1FYlEubm506ZNs7CwsLe3P3XqFN04JSVFKBTa2tquWLHCzs5OKBT6+fndunWL3hoREcHn8wcOHEgvfvnll6amphwOp6amhhASGRm5du3akpISDocjkUgIIZcuXbKwsEhISOihj5aSkkJR1MyZM9/eFB8fP3To0CNHjly5cqXdfSmKSkpKGj58uEAgsLKymjVr1q+//kpv0t5FhJC2tratW7c6ODiYmJiMHDkyMzOzC8E/ffrUxMTEycmp05YKheLmzZteXl5a2lhZWU2ePDk5Oblv35bvjZA4AXqfiRMn/vDDD6rFL774Ys2aNXK53NzcPDMzs6SkxNnZefny5S0tLYSQiIiIsLAwmUy2evXq0tLSO3futLa2fvTRR/QdxZSUFPXZ/lJTU3fs2KFaTE5OnjFjhouLC0VRxcXFhBD6jRWlUtlDH+3ChQvDhg0TiURvbzIxMfnLX/5iZGS0fPnypqamtxts3749JiZm06ZNVVVV//znPysqKiZNmvTixQvSWRcRQjZs2LBnz559+/b99ttvM2bMWLhw4U8//cQocplMdvXq1eXLl/P5fNXKmJgYKysrPp/v5OQ0a9as27dv0+ufPXumUCj+/e9/T5kyhf5rZvjw4ampqRo5cvTo0U+fPr179y6jSKCnIXEC9B1+fn4WFhY2NjahoaFNTU3l5eWqTVwul74UGzFiRFpaWkNDQ3p6ehdOERgYWF9fv2XLlncX9f9pamp68uSJi4tLRw18fX3XrFlTWlq6YcMGjU1yuTwpKWn27NmLFy8Wi8Wenp4HDx6sqak5dOiQerN2u6i5uTktLS04OHjOnDmWlpabN2/m8XhM+ycxMdHOzi4+Pl615rPPPjt37lxFRUVjY+OpU6fKy8snT54slUoJIfRLQDY2NgkJCVKp9MWLF7NmzVq1atXJkyfVj+nq6koIuX//PqNIoKchcQL0QfRFj+pySsOYMWNEIpHqNqbhqKqqoiiq3ctNlfj4+GHDhqWmpl6/fl19vVQqbWxsHDNmjGrN2LFj+Xy+6qa0BvUuevjwoUwmU72YY2JiMnDgQEb9c/bs2aysrO+//179habBgwePHj3azMyMz+f7+Pikp6fL5fLU1FRCiEAgIIS4u7v7+flZW1uLxeIdO3aIxWKNNE93BX3RDIYDiRPgfSQQCKqrq9mOQlNzczP5Pal0RCgUpqenczicpUuXyuVy1Xp65IaZmZl6Y0tLy4aGhk7PS9/43bx5s2rAZVlZmY7v+BBCMjIydu3alZ+fP2TIEC3NPD09jY2NHz16RAixs7MjhNAPkml8Pt/R0bGkpER9FxMTE/J7t4DhQOIEeO+0tLTU1dXZ29uzHYgmOk90OvCfLtpcVFQUFxenWmlpaUkI0UiTOn5MGxsbQsi+ffvUh47oWOFy//79x48fv3r16gcffKC9pVKpVCqV9J8FZmZmrq6uDx48UG/Q2toqFovV1ygUCvJ7t4DhQOIEeO/k5+dTFOXj40Mvcrncjm7q6pmtrS2Hw9FlpGZcXJybm1tBQYFqjYeHh5mZmfobPbdu3VIoFB9++GGnRxs8eLBQKCwsLGQULUVR0dHR9+/fz8nJ0bjSpX388cfqi7dv36YoytfXl14MCQkpKCh4/PgxvSiTycrKyjRGp9BdMWDAAEaBQU9D4gR4LyiVylevXrW2tt67dy8yMtLBwSEsLIzeJJFIXr58mZOT09LSUl1dXVZWpr6jtbX1s2fPSktLGxoaWlpa8vLyem44ikgkcnZ2rqys7LQlfcNWfQylUChcu3bt2bNnjx8/Xl9ff//+/ZUrV9rZ2YWHh+tytM8///zUqVNpaWn19fVtbW2VlZW//fYbISQ0NHTAgAHtTun34MGDPXv2HD58mMfjqc+r9/XXX9MNnj59mpGRUVdX19LScuPGjWXLljk4OKxcuZLeGhUV5ejoGBYWVl5eXltbGx0dLZfLNV56ortCy1hPYAUSJ0Dvc+DAgbFjxxJCoqOjg4KC0tLS9u3bRwgZOXLk48ePDx8+vHbtWkLIJ598UlRURO/S3Nzs6elpYmIyadKkoUOH/uMf/1A9Svziiy+mTJmyYMGCYcOGxcXF0TcGfX196fEqK1eutLW1HTFixPTp01++fNnTHy0wMFAqlaoeXv7tb3+TSCQlJSVjx4796quv1Fv6+PhERUWpr9m2bVtiYmJsbGz//v0nT548ZMiQ/Px8U1NTQkinXZScnLxmzZrdu3f369fPzs4uMjLy1atXhBCFQlFVVZWbm/t2qJ0Or/zkk082b95sb28vEonmz58/YcKEmzdv9uvXj95qZWX1r3/9y97e3svLa9CgQT/++OOFCxc0Rnbevn170KBBI0eOZNCD0PM4GFqrN/QkltnZ2WwHAoaFw+FkZmaqD6Z851asWJGdnV1bW9tzp+iUjt//4uLi4cOHp6enL168WC9xdUKpVPr7+4eFhS1dulTPp66trbW3t4+Pj6dzvBb43aJnuOIEeC/0llIbEokkNjY2NjZWvcwIW9ra2nJychoaGkJDQ/V/9u3bt3t5eUVEROj/1KAdEicAGJaYmJh58+aFhoayPp97fn7+mTNn8vLytA8t7QlJSUmFhYUXL17k8Xh6PjV0ConToC1btszc3JzD4TB938/QaC9bqIV6OUYan8+3tbX19/ffu3cv/RQKtNu4cWN6evrr16+dnJxOnz7Ndjg6SUhIiIiI2LlzJ7thTJ069cSJE6qJfPUmNzf3zZs3+fn5VlZWej416AKJ06AdOXLk8OHDbEfxDnS5bKGqHKNYLKYoSqlUVlVVZWVlOTk5RUdHu7u7M51Q9D2UmJj45s0biqKePHkyd+5ctsPRVUBAwK5du9iOgh1BQUExMTHq7wyDQUHihC5iVKax07KFOuJwOJaWlv7+/unp6VlZWS9evKDLUjI9Tk/Tfw1LANAbJE5Dx+Fw2A6hfYzKNHanbGFH5s6dGxYWVlVVdfDgwe4cpyfouYYlAOgTEqfBoShq7969w4YNEwgEYrF4/fr1qk179uwRiUTm5uZVVVVr164dNGjQw4cPtdQg1F6IkWitX8i0TCMjGmULu1zikR7Cn5eX15c6BwAMHQX6Mnfu3Llz53babNOmTRwO589//vOrV69kMhldS6GgoEC1lRCyevXq/fv3z549+5dfftm6dSufzz927FhdXd29e/e8vb379+///Plzun14eLipqemDBw+am5ulUunYsWPNzc3Ly8vprdr3XbRo0YABA1SB7d27lxBSXV1NL86ZM4cu08hUU1OTubl5RESEas358+fNzc1jY2M72kX1jFNDfX09IWTw4MG9unMIIZmZmTo27r10/P5DF6Bv9QyJU390+XLLZDKRSPTRRx+p1tBF6jUSp1wuV7U3MzMLDQ1Vtf/xxx8JIaokFB4erp5y6Dq6O3bs0GXfHkqcmzZtGjp0aH19ve67dJQ4KYqin3qqjtwbOweJE7oJfatnXD1f4IJ2xcXFMpls6tSpOrZnWoNQvRAj033fCbps4eXLl9XLFnZZU1MTRVEWFhbtbu1FnRMSEhISEtITRzY0BvvMvrfrRe9L9wFInIaFntOZLnKkiy7UIFQVYuxO/cKuycjISEpKys/P77QAk47o0oZubm7tbu1FnRMZGakqmtFX0VPFrlmzhu1A+iC6b0FvkDgNi1AoJIS8efNGx/ZMaxCqF2LsTv3CLti/f//3339/9erVdgswdc2lS5cIIdOmTWt3ay/qHF9f3x6dq9YQ0DOp9vmPyQrMUqtneKvWsHh4eBgZGV27dk339oxqEKoXYux033dVppHqrGxh1zx//nzfvn329vYdzb7dKzoHAHodJE7DYmNjM2fOnNOnTx89erS+vv7evXuHDh3S0l6XGoQdFWLsdF9GZRq1BNlp2UJdSjxSFNXY2KhUKimKqq6uzszMnDBhgrGxcU5OTkfPOHtF5wBA78Pmm0nvGR3ffGtoaFi2bFm/fv3MzMwmTpy4detWQoi9vf3du3d3795N10ocPHjwsWPH6PZKpXLv3r2urq48Hs/Kyio4OJgev0gLDw/n8XiDBg3icrkWFhazZs0qKSlRbdW+b21t7ZQpU4RCoZOT01dffUWPKJVIJPSAjTt37jg6OpqYmEycOFE1SKNd9+/fb/e7t3fvXrrBxYsXzc3N4+Pj39733LlzI0eOFIlEfD7fyMiI/D550Lhx42JjY2tra1Ute2nnUHirFroNfatnqMepP6zUzDOEQowGy0A6Rw/1OA0Bakb2HPStnuFWbd/XWwoxsgKdAwBMIXFCd/3666+cjrFSARj6gCtXrsTExKjXlVuyZIl6g4CAAHNzc2NjY3d39zt37rASpPZ6efHx8Ro/Dh4eHuq7t7S0JCYmSiQSPp9vaWnp4eFRWlpKCDl37tzu3bvxV53BQuLsy/RTiNHNzU3Lw4CMjIweOm839cYqle+Pbdu2paSkbNy4UVVXrl+/fsePH79w4YKqzeXLl7Ozs2fMmCGVSr29vVmJs8v18mghISHffvvtiRMnZDLZL7/84uLiQufdmTNnCoXCqVOn0uOJwdAgcfZlvbQQo368P53zDmuc6adc2q5duzIyMrKystSnl0pJSTEyMgoPDzeoKnKd1stTvadG+/nnn1WbMjIycnJysrOzx48fz+Vy7ezscnNzVZekq1evHjVq1PTp01tbW/X9qaAzSJwAfdw7rHGmh3JpxcXFW7Zs2bFjBz0ZiIqfn19kZOTTp0/XrVvXowEw0p16ed988423t7enp2dHDbZv315YWJicnNz9OOHdQuIE6AWod1TjTHsxNabl0rpcD06LlJQUiqJmzpz59qb4+PihQ4ceOXLkypUrTHspLS3N1NRUJBLl5uZOmzbNwsLC3t6erqBAa2tr27p1q4ODg4mJyciRIzMzM7sQvEa9PC0UCsXNmze9vLy0tLGyspo8eXJycjLGPhicnhrnAm/BWCtoF9FhHOc7rHGmvZgao0N1Wg9OnY7ff2dn5xEjRmisdHFxefLkCUVRP/zwg5GR0ZAhQxobGymKysvLCwoKUjXT3kt08Zy///3vr1+/rqqqmjRpkqmpqUKhoLeuW7dOIBCcPn361atXGzduNDIyun37ti6fS+XtenlxcXH29vaWlpY8Hm/IkCFBQUE//vgjvenJkyeEEC8vL39//4EDBwoEAjc3twMHDtBTfKjExMQQteJIHcHvFj3DFSeAoZPL5UlJSbNnz168eLFYLPb09Dx48GBNTY32WaW04HK59GXZiBEj0tLSGhoa0tPTu3CcwMDA+vr6LVu2dC2MtzU1NT158sTFxaWjBr6+vmvWrCktLd2wYYPGJh17yc/Pz8LCwsbGJjQ0tKmpqby8nBDS3NyclpYWHBw8Z84cS0vLzZs383g8pn2SmJhoZ2cXHx+vWvPZZ5+dO3euoqKisbHx1KlT5eXlkydPlkqlhBD6JSAbG5uEhASpVPrixYtZs2atWrXq5MmT6sd0dXUlhHQ0hQiwBYkTwND1aI0z9WJqrKuqqqIoSiQSaWkTHx8/bNiw1NTU69evq69n2kt8Pp8QQk+I+PDhQ5lMpnoxx8TEZODAgYz6hK6X9/3336u/0DR48ODRo0ebmZnx+XwfH5/09HS5XE6XphcIBIQQd3d3Pz8/a2trsVi8Y8cOsViskebprnjx4oXukYAeIHECGLqernGmKqbGuubmZvJ7UumIUChMT0/ncDhLly6Vy+Wq9d3ppaamJkLI5s2bVQMuy8rKdHzHhxCSkZGxa9eu/Pz8IUOGaGnm6elpbGxM18Kzs7MjhNAPj2l8Pt/R0bGkpER9F3oWSbpbwHAgcQIYuh6tcaZeTI11dJ7odOC/r69vVFRUUVFRXFycamV3eomugLtv3z7151g3btzQJeb9+/cfP3786tWrnVaZVSqVSqWS/rPAzMzM1dX1wYMH6g1aW1vFYrH6GoVCQX7vFjAcSJwAhq5Ha5ypF1Pr5qG6z9bWlsPh6DJSMy4uzs3NraCgQLWGaRU5dYMHDxYKhYWFhYyipTqrl/fxxx+rL9JvG6kqloeEhBQUFDx+/JhelMlkZWVlGqNT6K4YMGAAo8CgpyFxAhi6d17jrKNiakwPpUs9OEZEIpGzs3NlZWWnLekbtupjKHWpIqflaJ9//vmpU6fS0tLq6+vb2toqKyt/++03QkhoaOiAAQPandKv03p5T58+zcjIqKura2lpuXHjxrJlyxwcHFauXElvjYqKcnR0DAsLKy8vr62tjY6OlsvlGi890V2hZawnsIONV3nfU3hlHNpFdBiO8g5rnGkvpsboUFrqwb1Nx+9/REQEj8eTyWT04tmzZ+mXbPv3779q1SqNxuvXr1cfjqKll1JTU+kXbVxdXUtKSg4dOkSXcXV0dHz06BFFUW/evImOjnZwcOByuXRZXKlUSlFUcHAwIWTr1q1vh9ppvby1a9e6uLiYmppyuVx7e/vly5c/e/ZM/QgVFRULFiywsrISCATjxo3Ly8vTOEVgYOCgQYM0xqi8Db9b9AxlxfQHpX+gXXouK8ZWMTUdv//FxcXDhw9PT09fvHixXuLqhFKp9Pf3DwsLW7p0qZ5PXVtba29vHx8fv3btWu0t8btFz3CrFuC9Y8hlNyQSSWxsbGxsrHqZEba0tbXl5OQ0NDSwUuRn+/btXl5eERER+j81aIfECQCGJSYmZt68eaGhoazP556fn3/mzJm8vDztQ0t7QlJSUmFh4cWLF3k8np5PDZ1C4gR4j/SWYmoJCQkRERE7d+5kN4ypU6eeOHFCNXmv3uTm5r558yY/P9/KykrPpwZdcNkOAAD0JzExMTExke0odBIQEBAQEMB2FOwICgoKCgpiOwroEK44AQAAGEDiBAAAYACJEwAAgAEkTgAAAAbwcpBeVVZWZmVlsR0FGBwd5xPv1ejZ4/D97wmVlZUGMk3/ewIzB+nPvHnzDHkAAAD0XnPnzsXMQXqDxAlgiOgZ+HB9BmCA8IwTAACAASROAAAABpA4AQAAGEDiBAAAYACJEwAAgAEkTgAAAAaQOAEAABhA4gQAAGAAiRMAAIABJE4AAAAGkDgBAAAYQOIEAABgAIkTAACAASROAAAABpA4AQAAGEDiBAAAYACJEwAAgAEkTgAAAAaQOAEAABhA4gQAAGAAiRMAAIABJE4AAAAGkDgBAAAYQOIEAABgAIkTAACAASROAAAABpA4AQAAGEDiBAAAYACJEwAAgAEkTgAAAAaQOAEAABhA4gQAAGAAiRMAAIABDkVRbMcAAOTEiRNHjx5VKpX04pMnTwghTk5O9KKRkdF///d/L1q0iLX4AOB3SJwABuHevXujRo3S0uDu3bsjR47UWzwA0BEkTgBD4ebm9vDhw3Y3SSSSoqIiPccDAO3CM04AQ7FkyRIej/f2eh6P9/nnn+s/HgBoF644AQzF48ePJRJJuz+SRUVFEolE/yEBwNtwxQlgKJydnb29vTkcjvpKDoczZswYZE0Aw4HECWBAPv30U2NjY/U1xsbGn376KVvxAMDbcKsWwIBUVVXZ2dmpBqUQQoyMjJ49ezZgwAAWowIAdbjiBDAgtra2kydPVl10Ghsb+/v7I2sCGBQkTgDDsmTJEvX7QEuWLGExGAB4G27VAhiW+vp6GxsbhUJBCOHxeFVVVZaWlmwHOQnxIAAAIABJREFUBQD/B1ecAIbFwsLik08+4XK5XC53+vTpyJoAhgaJE8DgLF68uK2tra2tDZPTAhgg3KoFMDjNzc39+/enKKqmpsbExITtcADgPyBxGrp58+adPn2a7SgAQE/mzp2bnZ3NdhSgDZftAKBzPj4+a9asYTsK6FxISEhkZKSvr2/3D1VYWMjhcLTXS2HLvn37CCH4TvYEum/BwCFx9gL29vbz589nOwroXEhIiK+v7zv5z5o9ezYhhMs1xJ9Q+noI38megGvNXsEQfywBwDBTJgAQvFULAADACBInAAAAA0icAAAADCBxAgAAMIDECcCyixcvisXi7777ju1AesqVK1diYmLOnDnj7OzM4XA4HI7GzPUBAQHm5ubGxsbu7u537txhJcjY2NgRI0ZYWFgIBAKJRPKnP/2psbFRtTU+Pp7znzw8PNR3b2lpSUxMlEgkfD7f0tLSw8OjtLSUEHLu3Lndu3e3tbXp+eNAj0LiBGBZ356EZNu2bSkpKRs3bpwzZ87jx49dXFz69et3/PjxCxcuqNpcvnw5Ozt7xowZUqnU29ublTivXr26atWq0tLSmpqaxMTE5OTkefPm6b57SEjIt99+e+LECZlM9ssvv7i4uNB5d+bMmUKhcOrUqXV1dT0WO+gbEicAywIDA1+/fj1jxoyePpFcLvfz8+vps6jbtWtXRkZGVlaWubm5amVKSoqRkVF4ePjr16/1GYx2ZmZm4eHh1tbW5ubm8+fPDw4OvnTpUkVFharBsWPHKDU///yzalNGRkZOTk52dvb48eO5XK6dnV1ubq7qknT16tWjRo2aPn16a2urvj8V9AwkToD3xdGjR6uqqvR2uuLi4i1btuzYsUMoFKqv9/Pzi4yMfPr06bp16/QWTKfOnz+vqh9OCOnfvz8hRCaT6bLvN9984+3t7enp2VGD7du3FxYWJicndz9OMARInABsun79uoODA4fDOXDgACEkLS3N1NRUJBLl5uZOmzbNwsLC3t7+1KlTdOOUlBShUGhra7tixQo7OzuhUOjn53fr1i16a0REBJ/PHzhwIL345ZdfmpqacjicmpoaQkhkZOTatWtLSko4HI5EIiGEXLp0ycLCIiEhoYc+WkpKCkVRM2fOfHtTfHz80KFDjxw5cuXKlXb3pSgqKSlp+PDhAoHAyspq1qxZv/76K71JexcRQtra2rZu3erg4GBiYjJy5MjMzMwuBP/06VMTExMnJ6dOWyoUips3b3p5eWlpY2VlNXny5OTk5L59W/79gcQJwKaJEyf+8MMPqsUvvvhizZo1crnc3Nw8MzOzpKTE2dl5+fLlLS0thJCIiIiwsDCZTLZ69erS0tI7d+60trZ+9NFH9B3FlJQU9WnwUlNTd+zYoVpMTk6eMWOGi4sLRVHFxcWEEPqNFaVS2UMf7cKFC8OGDROJRG9vMjEx+ctf/mJkZLR8+fKmpqa3G2zfvj0mJmbTpk1VVVX//Oc/KyoqJk2a9OLFC9JZFxFCNmzYsGfPnn379v32228zZsxYuHDhTz/9xChymUx29erV5cuX8/l81cqYmBgrKys+n+/k5DRr1qzbt2/T6589e6ZQKP79739PmTKF/mtm+PDhqampGjly9OjRT58+vXv3LqNIwDAhcQIYIj8/PwsLCxsbm9DQ0KampvLyctUmLpdLX4qNGDEiLS2toaEhPT29C6cIDAysr6/fsmXLu4v6/zQ1NT158sTFxaWjBr6+vmvWrCktLd2wYYPGJrlcnpSUNHv27MWLF4vFYk9Pz4MHD9bU1Bw6dEi9Wbtd1NzcnJaWFhwcPGfOHEtLy82bN/N4PKb9k5iYaGdnFx8fr1rz2WefnTt3rqKiorGx8dSpU+Xl5ZMnT5ZKpYQQ+iUgGxubhIQEqVT64sWLWbNmrVq16uTJk+rHdHV1JYTcv3+fUSRgmJA4AQwafdGjupzSMGbMGJFIpLqNaTiqqqooimr3clMlPj5+2LBhqamp169fV18vlUobGxvHjBmjWjN27Fg+n6+6Ka1BvYsePnwok8lUL+aYmJgMHDiQUf+cPXs2Kyvr+++/V3+hafDgwaNHjzYzM+Pz+T4+Punp6XK5PDU1lRAiEAgIIe7u7n5+ftbW1mKxeMeOHWKxWCPN011BXzRDb4fECdC7CQSC6upqtqPQ1NzcTH5PKh0RCoXp6ekcDmfp0qVyuVy1nh65YWZmpt7Y0tKyoaGh0/PSN343b96sGnBZVlam4zs+hJCMjIxdu3bl5+cPGTJESzNPT09jY+NHjx4RQuzs7Agh9INkGp/Pd3R0LCkpUd+FLkhOdwv0dkicAL1YS0tLXV2dvb0924FoovNEpwP/fX19o6KiioqK4uLiVCstLS0JIRppUsePaWNjQwjZt2+f+tCRGzdu6BLz/v37jx8/fvXq1Q8++EB7S6VSqVQq6T8LzMzMXF1dHzx4oN6gtbVVLBarr1EoFOT3boHeDokToBfLz8+nKMrHx4de5HK5Hd3U1TNbW1sOh6PLSM24uDg3N7eCggLVGg8PDzMzM/U3em7duqVQKD788MNOjzZ48GChUFhYWMgoWoqioqOj79+/n5OTo3GlS/v444/VF2/fvk1RlKpieUhISEFBwePHj+lFmUxWVlamMTqF7ooBAwYwCgwMExInQC+jVCpfvXrV2tp67969yMhIBweHsLAwepNEInn58mVOTk5LS0t1dXVZWZn6jtbW1s+ePSstLW1oaGhpacnLy+u54SgikcjZ2bmysrLTlvQNW/UxlEKhcO3atWfPnj1+/Hh9ff39+/dXrlxpZ2cXHh6uy9E+//zzU6dOpaWl1dfXt7W1VVZW/vbbb4SQ0NDQAQMGtDul34MHD/bs2XP48GEej6c+r97XX39NN3j69GlGRkZdXV1LS8uNGzeWLVvm4OCwcuVKemtUVJSjo2NYWFh5eXltbW10dLRcLtd46YnuCi1jPaEXQeIEYNOBAwfGjh1LCImOjg4KCkpLS9u3bx8hZOTIkY8fPz58+PDatWsJIZ988klRURG9S3Nzs6enp4mJyaRJk4YOHfqPf/xD9Sjxiy++mDJlyoIFC4YNGxYXF0ffGPT19aXHq6xcudLW1nbEiBHTp09/+fJlT3+0wMBAqVSqenj5t7/9TSKRlJSUjB079quvvlJv6ePjExUVpb5m27ZtiYmJsbGx/fv3nzx58pAhQ/Lz801NTQkhnXZRcnLymjVrdu/e3a9fPzs7u8jIyFevXhFCFApFVVVVbm7u26F2Orzyk08+2bx5s729vUgkmj9//oQJE27evNmvXz96q5WV1b/+9S97e3svL69Bgwb9+OOPFy5c0BjZefv27UGDBo0cOZJBD4Kh4mBAroGjJ8zMzs5mOxDoHIfDyczMVB9M+c6tWLEiOzu7tra2507RKR2/k8XFxcOHD09PT1+8eLFe4uqEUqn09/cPCwtbunSpnk9dW1trb28fHx9P53gt8PPeK+CKE6CX6S2lNiQSSWxsbGxsrHqZEba0tbXl5OQ0NDSEhobq/+zbt2/38vKKiIjQ/6mhJyBx9kHLli0zNzfncDhMX5HoaUqlct++fYzmGVevRUXj8/m2trb+/v579+6lb8GBwYqJiZk3b15oaCjr87nn5+efOXMmLy9P+9DSnpCUlFRYWHjx4kUej6fnU0MPQeLsg44cOXL48GG2o9BUVFT0hz/8ISoqSvdBdYQQVS0qsVhMUZRSqayqqsrKynJycoqOjnZ3d2c6m1qvtnHjxvT09NevXzs5OZ0+fZrtcHSSkJAQERGxc+dOdsOYOnXqiRMnVBP56k1ubu6bN2/y8/OtrKz0fGroOVy2A4D3wt27d2NjY1euXNnU1NSdx+ocDsfS0tLf39/f3z8wMDAkJCQwMPDRo0caY+b6qsTExMTERLajYCwgICAgIIDtKNgRFBQUFBTEdhTwjuGKs2/icDhsh/AfRo0adebMmUWLFmmfSoaRuXPnhoWFVVVVHTx48F0dEwCgU0icfQRFUXv37h02bJhAIBCLxevXr1ff2m6hpU7LM127dm3cuHEikcjCwsLT07O+vr6jQ3VTl+tb0eMX8/LyesXHBIC+AYmzj9iyZUt0dHR4ePiLFy+eP3+uMfi63UJL2sszNTU1zZw5c+7cuS9fviwqKho6dCg9Z1j3aza9rcv1reihcqoZWwz8YwJAH0GBYZs7d+7cuXO1t5HJZCKR6KOPPlKtoa+oCgoKKIqSy+UikSg0NFTVWCAQfPHFFxRFbdq0iRAil8vpTXS1h+LiYoqifv75Z0LI+fPn1U+k5VA6Gj9+/KhRo3RvT1O9HPQ2+qmn9tj09jEJIZmZmUw/Xa+jy3cSugZ92yvg5aC+oLi4WCaTTZ06td2tuhdaUi/P5OzsbGtru3jx4tWrV4eFhdHFIrpfs+ndol81srCwYBRbj35MHecT79Xo2eOysrLYDqQPqqysNMAp+0ET25kbOqHLX6AXL14khBw9elS1Rv2K83//93/f/n/38fGh3roUowex/PLLL/Tizz///Mc//pHL5XI4nJCQEJlMpuVQOnq3V5z0vKMBAQEG8jG78YMI8P/hitPw4RlnXyAUCgkhb968aXdrlwstubu7f/fdd8+ePYuOjs7MzPz666+7U7OpJ1y6dIkQMm3aNGIwHxO3aqE75s6d260fCdALJM6+wMPDw8jI6Nq1a+1u7VqhpWfPntElBm1sbHbu3Ont7f3gwYOuHaqHPH/+fN++ffb29vTUo331YwKAoUHi7AtsbGzmzJlz+vTpo0eP1tfX37t379ChQ6qtWgotafHs2bMVK1b8+uuvCoWioKCgrKzMx8ena4fqlC71rSiKamxsVCqVFEVVV1dnZmZOmDDB2Ng4JyeHfsZp+B8TAPoItu9MQCd0vC3W0NCwbNmyfv36mZmZTZw4cevWrYQQe3v7u3fvUhT15s2b6OhoBwcHLpdLZ1mpVJqamkrP2+nq6lpSUnLo0CE6Azk6Oj569Ki0tNTPz8/KysrY2PiDDz7YtGlTa2trR4fqNLwbN25MmDDBzs6O/tYNHDjQz8/v2rVr9NaLFy+am5vHx8e/veO5c+dGjhwpEon4fL6RkRH5ffKgcePGxcbG1tbWqjdm/WMS3KqF7kHf9gooK2boUGaoF9FDWTFDgO9kz0Hf9gq4VQsAAMAAEid016+//srpGCvlDwEAeg4SJ3SXm5ublocBGRkZbAcILLty5UpMTIx6adUlS5aoNwgICDA3Nzc2NnZ3d6fH5rKlo5KxsbGxI0aMsLCwEAgEEonkT3/6k0Z17pMnT44dO9bc3NzR0fHzzz9//vw5vf7cuXO7d+/uLbXHQUdInADQg7Zt25aSkrJx40ZVadV+/fodP378woULqjaXL1/Ozs6eMWOGVCr19vZmK1QtJWOvXr26atWq0tLSmpqaxMTE5ORk+mEkLTMzc9GiRfPmzausrMzNzf3nP/85bdq01tZWQsjMmTOFQuHUqVPr6ur0+mGgJyFxAvQacrn87Ysh1g+lxa5duzIyMrKysszNzVUrU1JSjIyMwsPDX79+3dMB6O7u3bsbNmxYuXIlXTlAg5mZWXh4uLW1tbm5+fz584ODgy9dulRRUUFv/Z//+Z8PPvhg/fr1YrHYy8srKiqqsLDw1q1b9NbVq1ePGjVq+vTpdCqFPgCJE6DXOHr0aFVVlaEdqiPFxcVbtmzZsWMHPbOVip+fX2Rk5NOnT9etW9ejATCivWTs+fPnjY2NVYv9+/cnhKguTCv+X3v3HtXE1e4PfAfIhUDCRUBQRAPBKwq12leCrVpO6bEcRBQsVfq+aGvRaiOCFEGhiIgiPcDBF5YFe+hata2AUrQqtkdZ6HFVPe1SlOKpAoqCily8EO6XzO+PWZ1fTrglEJKA389fzp7Jnmf2ij7OZPZ+amrs7OyYIrhTpkwhhDx48IA5Pi4urrS0NC0tbfTiB21C4gTQKoqiUlJSZs2axeVyLSwsVq5cySwfL5VKORyOra0tvbllyxYTExMWi9XY2EgICQ0NDQ8Pr6qqYrFYYrE4PT2dx+PZ2Nhs2rTJzs6Ox+NJJBLmLketrsgISqIOIj09naKoFStW9N2VkJAwffr0I0eOnD9/Xt1RGrLAqhZqqT569MjY2FgkEtGbjo6Oiv8LoX/gdHR0ZFosLCyWLFmSlpaG6X/jhDYmi8IIYEL0GEJUWAAhNjaWw+F8++23L168uHXr1vz5862srOrq6ui969atmzhxInNwcnIyIaShoYHeXL16tZOTE7M3JCTExMTk9u3bHR0d5eXl9MspDx8+HEZXp0+fFggE8fHxqlymit9JR0fH2bNnKzU6OTndv3+foqhff/3VwMBg2rRpLS0tFEUVFRX5+voyhw0+SvSq/RcuXHj58mV9ff2bb75pYmLS1dVF792xYweXyz1+/Pjz58+jo6MNDAx+++03Va6LNmQdgtbWVoFAIJVKmZaSkhI2m52ent7c3PzHH3/MmjXr3XffVfpUVFQU+avuwiDw931MwB0ngPa0t7enpKSsWrUqKCjIzMxs7ty5hw8fbmxsVFwiUS1GRkb0bdns2bMzMzNlMllOTs4w+vH29m5ubo6JiRleGH21trbev3/fyclpoAPc3d23b99eXV2tVHSdqDxKEolEKBRaW1sHBga2trY+fPiQENLR0ZGZmenn57d69Wpzc/Pdu3ez2ezhjclAEhMT7ezsEhISmJYlS5ZERkZKpVKhUOji4iKTyY4cOaL0KWdnZ0JIWVmZBiMBXUHiBNCe8vLylpaWBQsWMC0LFy7kcDjMI9aRWLBgAZ/P12F5VEX19fUURdGLHQ4kISFhxowZGRkZly9fVmxXd5QUC6yOdsnYgoKCvLy8n3/+WfF1p127dmVlZV24cKGlpeXevXsSicTd3Z15dYhGD8XTp081FQnoEBIngPbQcxJMTU0VG83NzWUymUb653K5DQ0NGulqhDo6Oggh/b5ow+DxeDk5OSwWa8OGDe3t7Uz7SEaptbWVELJ7925mCY4HDx70nV4yPMeOHTtw4EBJSQld8Jz25MmTpKSkTz755O233zYxMRGJRNnZ2Y8fP6afjTOMjY3JX8MCYx0SJ4D2mJubE0KUEsCLFy/s7e1H3nl3d7emuho5Ok8MOfHf3d09LCysoqJi7969TONIRmn0SsYeOnTo6NGjxcXFkyZNUmyvqKjo7e1VbBQKhZaWluXl5YqHdXV1kb+GBcY6JE4A7XFxcTE1Nf3999+ZlmvXrnV1db3++uv0ppGREf3IcRhKSkooilq0aNHIuxo5GxsbFoulykzNvXv3zpw588aNG0zLkKM0iNGopUpRVGRkZFlZWWFhodJ9MCGETueKVedkMtmzZ8/oSSkMeigmTpyowcBAV5A4AbSHx+OFh4cXFBQcPXq0ubm5rKxs8+bNdnZ2ISEh9AFisfjZs2eFhYXd3d0NDQ2KcwEJIZaWlo8fP66urpbJZHRSlMvlz58/7+npuXXrVmhoqIODQ3Bw8DC6UqUkqlr4fL6jo2Ntbe2QR9IPbBVnSQ45SoP3NlAt1cDAwIkTJw5jSb/bt28fPHgwOzubzWYrrsP85ZdfEkJEItGyZcuys7MvXbrU3t5eU1NDx/nRRx8pdkIPxdy5c9U9O+gjnbzLC6rD6+ljCFFhOopcLk9OTnZ2dmaz2RYWFn5+fnfu3GH2NjU1LVu2jMfjiUSizz77LCIighAiFovpSSbXr1+fOnWqsbHx4sWL6+rqQkJC2Gz25MmTjYyMhELhypUrq6qqhtfVICVR+1LxOymVStlsdltbG71ZUFBAv2RrZWW1detWpYMjIiIUp6MMMkqDF1ilBq6l6ufnRwiJjY3tN9pBSsYO9CpscnIy/dnGxsbQ0FCxWMzlck1NTT08PH788Uel/r29vSdPnkxXYh/52IJuoR6nvkN9vjFEy/U4N23alJ+f39TUpJ3TMVT8TlZWVs6aNSsnJycoKEgrcQ1BLpcvXbo0ODh4w4YNWj51U1OTvb19QkJCeHj44Efi7/uYgEe1AGOYPpfdEIvF8fHx8fHxSoVEdKK3t7ewsFAmk+mkzl1cXJybm5tUKtX+qWE0IHECwGiJiooKCAgIDAzU+XruJSUlJ06cKCoqGnxq6WhISUkpLS09e/Ysm83W8qlhlCBxAoxJ0dHROTk5L1++FIlEx48f13U4A9q3b59UKt2/f79uw/D09Pzuu++YxXu15uTJk52dnSUlJRYWFlo+NYweI10HAADDkZiYmJiYqOsoVOLl5eXl5aXrKHTD19fX19dX11GAhuGOEwAAQA1InAAAAGpA4gQAAFADEicAAIAa8HLQGHD16lV6WjTov9TU1HE/e/3q1avkr6n6oFlXr15lVhsGvYXEqe/c3d11HQKoyt/fX1Nd0Yuev/baa5rqUIPwL/voWbRoEf7K6z8suQegj+h1+/Ly8nQdCAAow2+cAAAAakDiBAAAUAMSJwAAgBqQOAEAANSAxAkAAKAGJE4AAAA1IHECAACoAYkTAABADUicAAAAakDiBAAAUAMSJwAAgBqQOAEAANSAxAkAAKAGJE4AAAA1IHECAACoAYkTAABADUicAAAAakDiBAAAUAMSJwAAgBqQOAEAANSAxAkAAKAGJE4AAAA1IHECAACoAYkTAABADUicAAAAakDiBAAAUAMSJwAAgBqQOAEAANSAxAkAAKAGJE4AAAA1IHECAACoAYkTAABADUa6DgAACCGkra2ts7OT2ezq6iKEPH/+nGnhcrl8Pl8HkQHA/8WiKErXMQAAyczM3LJlyyAHZGRkfPrpp1qLBwAGgsQJoBcaGhrs7Ox6e3v73WtoaPjkyRNra2stRwUAfeE3TgC9YG1t7enpaWho2HeXoaHhv/zLvyBrAugJJE4AfREUFNTvEyCKooKCgrQfDwD0C49qAfSFTCaztrZWfEWIxuFwGhoahEKhTqICACW44wTQFwKBwMfHh81mKzYaGRn5+voiawLoDyROAD2ybt26np4exZbe3t5169bpKh4A6AuPagH0SFdXl5WVlUwmY1pMTU0bGxu5XK4OowIARbjjBNAjHA4nICCAw+HQm2w2+/3330fWBNArSJwA+mXt2rX0skGEkO7u7rVr1+o2HgBQgke1APpFLpfb2to2NDQQQqysrOrq6vqd3AkAuoI7TgD9YmBgsHbtWg6Hw2az161bh6wJoG+QOAH0zgcffNDV1YXntAD6CdVRtOfKlSs1NTW6jgLGAIqiJkyYQAi5f/9+dXW1rsOBMWDKlCnu7u66juJVgd84tScgIOD48eO6jgIAxiF/f//8/HxdR/GqwB2nVuHLDX2xWKzc3Nw1a9YoNt6+fZsQMnv2bB0FpXkBAQGEEHz/RwM9tqA1SJwA+mg8pUyAcQYvBwEAAKgBiRMAAEANSJwAAABqQOIEAABQAxInAACAGpA4Acaks2fPmpmZ/fTTT7oOZLScP38+KirqxIkTjo6OLBaLxWJ9+OGHigd4eXkJBAJDQ8M5c+Zcv35dV3ESQuRyeWpqqkQiUWqPj4+fPXu2UCjkcrlisfjzzz9vaWlRPOD7779fuHChQCCYOnXq+vXr6+rq6PZTp04lJSX19vZq6QJATUicAGPS+F665IsvvkhPT4+Ojl69evW9e/ecnJwmTJhw9OjRM2fOMMf88ssv+fn5Pj4+5eXl8+fP11WoFRUVb731VlhYWFtbm9Ku4uLirVu3VldXNzY2JiYmpqWlKU64zM3NXbduXUBAQG1t7cmTJy9durR8+XK6jPmKFSt4PJ6np+eLFy+0ejGgGiROgDHJ29v75cuXPj4+o32i9vb2vvdSo+rAgQPHjh3Ly8sTCARMY3p6uoGBQUhIyMuXL7UZzOBu3ry5c+fOzZs3u7m59d1ramoaEhJiaWkpEAjWrFnj5+d37tw5Zt3Nr776atKkSREREWZmZm5ubmFhYaWlpdeuXaP3btu2zdXV9b333qNTKegVJE4AGMzXX39dX1+vtdNVVlbGxMTs2bOHx+MptkskktDQ0EePHu3YsUNrwQzJ1dX1xIkT69at67fY+OnTpxWL21hZWRFCmBvTmpoaOzs7FotFb06ZMoUQ8uDBA+b4uLi40tLStLS00YsfhgeJE2DsuXz5soODA4vF+uc//0kIyczMNDEx4fP5J0+eXL58uVAotLe3/+GHH+iD09PTeTyejY3Npk2b7OzseDyeRCJh7mykUimHw7G1taU3t2zZYmJiwmKxGhsbCSGhoaHh4eFVVVUsFkssFhNCzp07JxQK9+3bN0qXlp6eTlHUihUr+u5KSEiYPn36kSNHzp8/3+9nKYpKSUmZNWsWl8u1sLBYuXLln3/+Se8afIgIIb29vbGxsQ4ODsbGxvPmzcvNzdX4pT169MjY2FgkEtGbjo6Oiv8joX/gdHR0ZFosLCyWLFmSlpY2vh/Lj0VInABjz+LFi3/99Vdm89NPP92+fXt7e7tAIMjNza2qqnJ0dNy4cWN3dzchRCqVBgcHt7W1bdu2rbq6+vr16z09Pe+88w79zDA9PV1xmdyMjIw9e/Ywm2lpaT4+Pk5OThRFVVZWEkLoN1bkcvkoXdqZM2dmzJjB5/P77jI2Nv7mm28MDAw2btzY2tra94C4uLioqKhdu3bV19dfunSppqbmzTfffPr0KRlqiAghO3fuPHjwYGpq6pMnT3x8fNauXfv7779r8Lra2tqKi4s3btzI4XDolujo6Lq6ukOHDslksvLy8rS0tHfffXfRokWKn3rttdcePXp08+ZNDUYCI4fECTB+SCQSoVBobW0dGBjY2tr68OFDZpeRkRF9KzZ79uzMzEyZTJaTkzOMU3h7ezc3N8fExGgu6v+vtbX1/v37Tk5OAx3g7u6+ffv26urqnTt3Ku1qb29PSUlZtWpVUFCQmZnZ3LlzDx8+3NjYmJWVpXhYv0PU0dGRmZnp5+cXgw6RAAAgAElEQVS3evVqc3Pz3bt3s9ns4Y3PQBITE+3s7BISEpiWJUuWREZGSqVSoVDo4uIik8mOHDmi9ClnZ2dCSFlZmQYjgZFD4gQYh+jbGuZ2SsmCBQv4fD7zGFN/1NfXUxTV7+0mIyEhYcaMGRkZGZcvX1ZsLy8vb2lpWbBgAdOycOFCDofDPJRWojhEd+7caWtrc3FxoXcZGxvb2tpqcHwKCgry8vJ+/vlnxdeddu3alZWVdeHChZaWlnv37kkkEnd3d6WSvfRQ0DfNoD+QOAFeRVwut6GhQddRKOvo6CCE9PuiDYPH4+Xk5LBYrA0bNrS3tzPt9MwNU1NTxYPNzc1lMtmQ56Uf/O7evZv1lwcPHvSdXjI8x44dO3DgQElJybRp05jGJ0+eJCUlffLJJ2+//baJiYlIJMrOzn78+HFycrLiZ42NjclfwwL6A4kT4JXT3d394sULe3t7XQeijM4TQ078d3d3DwsLq6io2Lt3L9Nobm5OCFFKkypeprW1NSEkNTWVUnDlypVhXIKSQ4cOHT16tLi4eNKkSYrtFRUVvb29io1CodDS0rK8vFzxsK6uLvLXsID+QOIEeOWUlJRQFMW8h2JkZDTQQ10ts7GxYbFYqszU3Lt378yZM2/cuMG0uLi4mJqaKr7Rc+3ata6urtdff33I3qZMmcLj8UpLS4cXdr8oioqMjCwrKyssLFS6DyaE0On8yZMnTItMJnv27Bk9KYVBD8XEiRM1GBiMHBInwCtBLpc/f/68p6fn1q1boaGhDg4OwcHB9C6xWPzs2bPCwsLu7u6GhgbFqYSEEEtLy8ePH1dXV8tksu7u7qKiotGbjsLn8x0dHWtra4c8kn5gqzhLksfjhYeHFxQUHD16tLm5uaysbPPmzXZ2diEhIar0tn79+h9++CEzM7O5ubm3t7e2tpbOaoGBgRMnThzGkn63b98+ePBgdnY2m81mKfjyyy8JISKRaNmyZdnZ2ZcuXWpvb6+pqaHj/OijjxQ7oYdi7ty56p4dRhcF2uLv7+/v76/rKEDvEEJyc3PV+sihQ4fomZd8Pn/FihUZGRn0WyTOzs5VVVVZWVlCoZAQMnXq1Lt371IUFRISwmazJ0+ebGRkJBQKV65cWVVVxfTW1NS0bNkyHo8nEok+++yziIgIQohYLH748CFFUdevX586daqxsfHixYvr6urOnj0rEAgSEhLUvUwVv/9SqZTNZre1tdGbBQUF9Eu2VlZWW7duVTo4IiLC19eX2ZTL5cnJyc7Ozmw228LCws/P786dO/SuIYeos7MzMjLSwcHByMjI2tp69erV5eXlFEX5+fkRQmJjY/uN9sqVKx4eHnZ2dvQ/p7a2thKJ5OLFixRFDfQqbHJyMv3ZxsbG0NBQsVjM5XJNTU09PDx+/PFHpf69vb0nT54sl8s1MragKSwKU2u1hV6mMj8/X9eBgH5hsVi5ubmKkyk1btOmTfn5+U1NTaN3iiGp+P2vrKycNWtWTk5OUFCQVuIaglwuX7p0aXBw8IYNG7R86qamJnt7+4SEhPDw8MGPxL8tWoZHtQCvhLFSakMsFsfHx8fHxysVEtGJ3t7ewsJCmUwWGBio/bPHxcW5ublJpVLtnxoGh8Sp1z7++GOBQMBisTT72oL2JSUlzZw509jY2MTEZObMmTExMc3Nzap8ULGqFI3D4djY2CxdujQ5Ofn58+ejHTloX1RUVEBAQGBgoM7Xcy8pKTlx4kRRUdHgU0tHQ0pKSmlp6dmzZ9lstpZPDUNC4tRrR44cyc7O1nUUGvDf//3fGzdufPjw4dOnT/fu3ZuUlOTv76/KB5mqUmZmZhRFyeXy+vr6vLw8kUgUGRk5Z84cza6LNi5FR0fn5OS8fPlSJBIdP35c1+GoZN++fVKpdP/+/boNw9PT87vvvmMW8tWakydPdnZ2lpSUWFhYaPnUoAokThgmtapNcTicLVu2WFtbm5qaBgQErFy58r/+678U38VXEYvFMjc3X7p0aU5OTl5e3tOnT+nqWur2M9q0X4prEImJiZ2dnRRF3b9/X8X/r+gDLy+vAwcO6DoK3fD19Y2KilJ8Zxj0ChKnvmOqDukbtapNFRQUKFaJmjx5MiFkhD9i+fv7BwcH19fXHz58eCT9jAYtl+ICAG1C4tQ7FEUlJyfPmDGDy+WamZnRcwNoBw8e5PP5AoGgvr4+PDx88uTJ9Nv2A5VSGryeFBm0DJO61abUUlFRYW5uPnXqVHpz2JWq6JmIRUVF42lwAEDf6W4mzCtHxblWu3btYrFY//7v//78+fO2traMjAxCyI0bN5i9hJBt27YdOnRo1apV//u//xsbG8vhcL799tsXL17cunVr/vz5VlZWdXV19PEhISEmJia3b9/u6OgoLy9fuHChQCCg5+dRFDX4Z9etWzdx4kQmMHoVzYaGBnpz9erVdLUp1XV1ddXW1h46dIjL5X777bdM++nTpwUCQXx8/EAfZH7jVEK/YTRlypQxPThE/XmcYxHmGo4ejK2WIXFqjypf7ra2Nj6f/8477zAtdK1dpcTZ3t7OHG9qahoYGMgc/z//8z+EECYJhYSEKKac3377jRCyZ88eVT6r8cRJrxw2YcKE//iP/+jq6lL9gwMlToqi6F896T+P0cFB4oQRwthqmZF2729hCJWVlW1tbZ6enioer24pJcV6Uup+duRqampevHhx48aNqKiorKys4uJiGxubkXTY2tpKURS9BExfY2hwUlNTx/3s9atXr5K/puqDZl29elWpAjaMKvzGqV/opSnpWg2qGEYpJaae1EjKMA0Pm822trb28vI6duxYeXl5YmLiCDu8e/cuIWTmzJn97h1bgwMAYwXuOPUL/eppZ2eniserW0pJsZ7USMowjZBYLDY0NFSqoDQM586dI4QsX768371jaHC2b98+qkvu6QMsCzd6cB+vZbjj1C8uLi4GBgYXL15U/Xi1Sikp1pMa8rOaqjbV1NS0du1axRa6GKFSBSV11dXVpaam2tvbD7SI6JgYHAAYc5A49QtdluH48eNff/11c3PzrVu3srKyBjlelVJKA9WTGvKzalWbGiRIExOTX375pbi4uLm5ubu7+8aNG//4xz9MTEzCwsLoA1SpVEVRVEtLC10moqGhITc318PDw9DQsLCwcKDfOMfE4ADA2KPTV5NeLSq++SaTyT7++OMJEyaYmpouXrw4NjaWEGJvb3/z5s2kpCS6FvyUKVOY6RyDlFKihqonNfhn1ao2NfhFrVixQiQSmZqacrlcJyenwMDAsrIyZu8glapOnTo1b948Pp/P4XAMDAzIX4sHvfHGG/Hx8U1NTcyRY3dwCN6qhZHB2GoZyoppj05+49GHelJ6S08GRwtlxfQBfuMcPRhbLcOj2vFvrNST0gkMDgCoC4kTRurPP/9kDUwnhQxhHDh//nxUVJRiXbkPP/xQ8QAvLy+BQGBoaDhnzpzr16/rKk5CiFwuT01N7busf3x8/OzZs4VCIZfLFYvFn3/+udL6zN9//z29XtXUqVPXr19fV1dHt586dSopKQn/q9Nfun5W/ArR/u8QUVFRHA6HEDJt2rT8/Hxtnlr/6c/gEPzG2UdsbKyPj09zczO96eTkNGHCBELI6dOnFQ8rKiry9fXVcKBqunv3roeHByHE1dVVadeSJUsyMjKampqam5tzc3PZbPa//uu/MnuPHTtGCElKSqJXBXF0dHRzc+vu7qb3pqWlLVmy5Pnz56rEgN84tQx3nOPZGK0npR2vzuBosMaZdsqlHThw4NixY3l5eQKBgGlMT083MDAICQnRqypyN2/e3Llz5+bNm93c3PruNTU1DQkJsbS0FAgEa9as8fPzO3fuXE1NDb33q6++mjRpUkREhJmZmZubW1hYWGlpKbM01bZt21xdXd97772enh7tXQ+oBokTYJzTYI0zLZRLq6ysjImJ2bNnj2IdOkKIRCIJDQ199OjRjh07RjUAtbi6up44cWLdunVcLrfv3tOnTyvW1LSysiKEtLW10Zs1NTV2dnZM3UB6WrPivKa4uLjS0tK0tLTRix+GB4kTYAygNFTjbPBiauqWSxt2PbhBpKenUxS1YsWKvrsSEhKmT59+5MiR8+fPqztKmZmZJiYmfD7/5MmTy5cvFwqF9vb2dAUFWm9vb2xsrIODg7Gx8bx583JzczV4UbRHjx4ZGxuLRCJ609HRUfF/IfQPnI6OjkyLhYXFkiVL0tLSKMx90De6fE78isHvENAvosJvnBqscTZ4MTW1uhqyHpwiFb//jo6Os2fPVmp0cnK6f/8+RVG//vqrgYHBtGnTWlpaqD6/cQ4+SnTxnAsXLrx8+bK+vv7NN980MTFhqvTs2LGDy+UeP378+fPn0dHRBgYGv/32myrXRfvb3/7W9zdORa2trQKBQCqVMi0lJSVsNjs9Pb25ufmPP/6YNWvWu+++q/SpqKgoolAcaSD4t0XLcMcJoO/a29tTUlJWrVoVFBRkZmY2d+7cw4cPNzY2Dr6q1CCMjIzo27LZs2dnZmbKZLKcnJxh9OPt7d3c3BwTEzO8MPpqbW29f/++k5PTQAe4u7tv3769urp6586dSrtUHCWJRCIUCq2trQMDA1tbWx8+fEgI6ejoyMzM9PPzW716tbm5+e7du9ls9vDGZCCJiYl2dnYJCQlMy5IlSyIjI6VSqVAodHFxkclkR44cUfqUs7MzIaSsrEyDkcDIIXEC6LtRrXGmWExN5+rr6ymK4vP5gxyTkJAwY8aMjIyMy5cvK7arO0r0O9X0goh37txpa2tzcXGhdxkbG9va2mpwTAoKCvLy8n7++WfF15127dqVlZV14cKFlpaWe/fuSSQSd3d35tUhGj0UT58+1VQkoBFInAD6brRrnDHF1HSuo6ODENLvizYMHo+Xk5PDYrE2bNjQ3t7OtI9klFpbWwkhu3fvZuYfP3jwgHmLZ4SOHTt24MCBkpKSadOmMY1PnjxJSkr65JNP3n77bRMTE5FIlJ2d/fjxY/rZOINeRZIeFtAfSJwA+m5Ua5wpFlPTOTpPDDnx393dPSwsrKKiYu/evUzjSEaJroCbmpqq+DvWlStXhnEJSg4dOnT06NHi4uJJkyYpttMFghQbhUKhpaWlUq29rq4u8tewgP5A4gTQd6Na40yxmNoIuxo5GxsbFoulykzNvXv3zpw588aNG0yLulXkFE2ZMoXH45WWlg4v7H5RFBUZGVlWVlZYWKh0H0wIodP5kydPmBaZTPbs2TOlWnv0UEycOFGDgcHIIXEC6DuN1zgbqJiaul2pUg9OLXw+39HRsba2dsgj6Qe2irMkVakiN0hv69ev/+GHHzIzM5ubm3t7e2tra+msFhgYOHHixGEs6Xf79u2DBw9mZ2ez2WzFRSi//PJLQohIJFq2bFl2dvalS5fa29tramroOD/66CPFTuihmDt3rrpnh9Glk3d5X014ZRz6RVSYjqLBGmeDF1NTq6tB6sH1peL3XyqVstnstrY2erOgoIB+ydbKymrr1q1KB0dERChORxlklDIyMugXbZydnauqqrKysugyrlOnTr179y5FUZ2dnZGRkQ4ODkZGRnRZ3PLycoqi/Pz8CCGxsbH9RnvlyhUPDw87Ozv6n1NbW1uJRHLx4kWKogZ6FTY5OZn+bGNjY2hoqFgs5nK5pqamHh4eP/74o1L/3t7ekydPpsvQjnxsQVNQVkx7UPoH+qXlsmK6Kqam4ve/srJy1qxZOTk5QUFBWolrCHK5fOnSpcHBwRs2bNDyqZuamuzt7RMSEsLDwwc/Ev+2aBke1QK8cvS57IZYLI6Pj4+Pj1cqJKITvb29hYWFMplMJ0V+4uLi3NzcpFKp9k8Ng0PiBAD9EhUVFRAQEBgYqPP13EtKSk6cOFFUVDT41NLRkJKSUlpaevbsWTabreVTw5CQOAFeIdHR0Tk5OS9fvhSJRMePH9d1OAPat2+fVCrdv3+/bsPw9PT87rvvmMV7tebkyZOdnZ0lJSUWFhZaPjWowkjXAQCA9iQmJiYmJuo6CpV4eXl5eXnpOgrd8PX19fX11XUUMCDccQIAAKgBiRMAAEANSJwAAABqQOIEAABQAxInAACAGrBykPYEBATo8wQAABi7/P39sXKQ1iBxas+VK1eUqtQCDCQ1NZUQsn37dl0HAmPDlClT3N3ddR3FqwKJE0Af0UvX5uXl6ToQAFCG3zgBAADUgMQJAACgBiROAAAANSBxAgAAqAGJEwAAQA1InAAAAGpA4gQAAFADEicAAIAakDgBAADUgMQJAACgBiROAAAANSBxAgAAqAGJEwAAQA1InAAAAGpA4gQAAFADEicAAIAakDgBAADUgMQJAACgBiROAAAANSBxAgAAqAGJEwAAQA1InAAAAGpA4gQAAFADEicAAIAakDgBAADUgMQJAACgBiROAAAANSBxAgAAqAGJEwAAQA1InAAAAGpA4gQAAFADEicAAIAajHQdAAAQQsi1a9du3rzJbN67d48QkpWVxbS4urr+7W9/00FkAPB/sSiK0nUMAEBOnz7t4+NjaGhoYGBACKH/YrJYLEKIXC7v7e396aef/u3f/k3HUQIAEieAnuju7raysmpubu53r1AobGho4HA4Wo4KAPrCb5wAeoHNZn/wwQf9psZBdgGA9iFxAuiLDz74oKurq297d3f32rVrtR8PAPQLj2oB9IVcLp80adLTp0+V2q2trevq6ujfPgFA5/BXEUBfGBgYfPjhh0qPZDkcTnBwMLImgP7A30YAPdL3aW1XV9cHH3ygq3gAoC88qgXQL87OzpWVlcymo6NjVVWVDuMBACW44wTQL0FBQWw2m/4zh8P5xz/+odt4AEAJ7jgB9EtlZaWzszOzeefOnenTp+swHgBQgjtOAP0iFotdXV1ZLBaLxXJ1dUXWBNA3SJwAeufvf/+7oaGhoaHh3//+d13HAgDK8KgWQO88fvx4ypQpFEXV1NRMnjxZ1+EAwP+BxKnvUlJSrly5ousoQNtKSkoIIUuXLtVxHKB17u7uYWFhuo4CBoNHtfruypUrV69e1XUUoJLjx4/X1tZqpCsHB4epU6dqpCuNu3r1Kr6To+Tq1av4j7L+Qz3OMWDRokX5+fm6jgKGxmKxtm/fvmbNmpF39ezZM0KIpaXlyLvSuICAAEIIvpOjgR5b0HNInAD6SD9TJgAQPKoFAABQCxInAACAGpA4AQAA1IDECQAAoAYkTgAdO3v2rJmZ2U8//aTrQEbL+fPno6KiTpw44ejoSC8l+OGHHyoe4OXlJRAIDA0N58yZc/36dV3FSQiRy+WpqakSiUSpPT4+fvbs2UKhkMvlisXizz//vKWlRfGA77//fuHChQKBYOrUqevXr6+rq6PbT506lZSU1Nvbq6ULAK1A4gTQsfG9CMkXX3yRnp4eHR29evXqe/fuOTk5TZgw4ejRo2fOnGGO+eWXX/Lz8318fMrLy+fPn6+rUCsqKt56662wsLC2tjalXcXFxVu3bq2urm5sbExMTExLS1OcN5Kbm7tu3bqAgIDa2tqTJ09eunRp+fLlPT09hJAVK1bweDxPT88XL15o9WJgNCFxAuiYt7f3y5cvfXx8RvtE7e3tfe+lRtWBAweOHTuWl5cnEAiYxvT0dAMDg5CQkJcvX2ozmMHdvHlz586dmzdvdnNz67vX1NQ0JCTE0tJSIBCsWbPGz8/v3LlzNTU19N6vvvpq0qRJERERZmZmbm5uYWFhpaWl165do/du27bN1dX1vffeo1MpjANInACviq+//rq+vl5rp6usrIyJidmzZw+Px1Nsl0gkoaGhjx492rFjh9aCGZKrq+uJEyfWrVvH5XL77j19+rShoSGzaWVlRQhhbkxramrs7OxYLBa9OWXKFELIgwcPmOPj4uJKS0vT0tJGL37QJiROAF26fPmyg4MDi8X65z//SQjJzMw0MTHh8/knT55cvny5UCi0t7f/4Ycf6IPT09N5PJ6Njc2mTZvs7Ox4PJ5EImHubKRSKYfDsbW1pTe3bNliYmLCYrEaGxsJIaGhoeHh4VVVVSwWSywWE0LOnTsnFAr37ds3SpeWnp5OUdSKFSv67kpISJg+ffqRI0fOnz/f72cpikpJSZk1axaXy7WwsFi5cuWff/5J7xp8iAghvb29sbGxDg4OxsbG8+bNy83N1filPXr0yNjYWCQS0ZuOjo6K/yOhf+B0dHRkWiwsLJYsWZKWlja+H8u/OpA4AXRp8eLFv/76K7P56aefbt++vb29XSAQ5ObmVlVVOTo6bty4sbu7mxAilUqDg4Pb2tq2bdtWXV19/fr1np6ed955h35mmJ6errjaX0ZGxp49e5jNtLQ0Hx8fJycniqIqKysJIfQbK3K5fJQu7cyZMzNmzODz+X13GRsbf/PNNwYGBhs3bmxtbe17QFxcXFRU1K5du+rr6y9dulRTU/Pmm28+ffqUDDVEhJCdO3cePHgwNTX1yZMnPj4+a9eu/f333zV4XW1tbcXFxRs3buRwOHRLdHR0XV3doUOHZDJZeXl5Wlrau+++u2jRIsVPvfbaa48ePbp586YGIwFdQeIE0EcSiUQoFFpbWwcGBra2tj58+JDZZWRkRN+KzZ49OzMzUyaT5eTkDOMU3t7ezc3NMTExmov6/2ttbb1//76Tk9NAB7i7u2/fvr26unrnzp1Ku9rb21NSUlatWhUUFGRmZjZ37tzDhw83NjZmZWUpHtbvEHV0dGRmZvr5+a1evdrc3Hz37t1sNnt44zOQxMREOzu7hIQEpmXJkiWRkZFSqVQoFLq4uMhksiNHjih9ytnZmRBSVlamwUhAV5A4AfQafVvD3E4pWbBgAZ/PZx5j6o/6+nqKovq93WQkJCTMmDEjIyPj8uXLiu3l5eUtLS0LFixgWhYuXMjhcJiH0koUh+jOnTttbW0uLi70LmNjY1tbWw2OT0FBQV5e3s8//6z4utOuXbuysrIuXLjQ0tJy7949iUTi7u7OvDpEo4eCvmmGsQ6JE2Bs43K5DQ0Nuo5CWUdHByGk3xdtGDweLycnh8Vibdiwob29nWmnZ26YmpoqHmxubi6TyYY8L/3gd/fu3ay/PHjwoO/0kuE5duzYgQMHSkpKpk2bxjQ+efIkKSnpk08+efvtt01MTEQiUXZ29uPHj5OTkxU/a2xsTP4aFhjrkDgBxrDu7u4XL17Y29vrOhBldJ4YcuI/XbS5oqJi7969TKO5uTkhRClNqniZ1tbWhJDU1FRKgUYqXB46dOjo0aPFxcWTJk1SbK+oqOjt7VVsFAqFlpaW5eXliod1dXWRv4YFxjokToAxrKSkhKIo5j0UIyOjgR7qapmNjQ2LxVJlpubevXtnzpx548YNpsXFxcXU1FTxjZ5r1651dXW9/vrrQ/Y2ZcoUHo9XWlo6vLD7RVFUZGRkWVlZYWGh0n0wIYRO50+ePGFaZDLZs2fP6EkpDHooJk6cqMHAQFeQOAHGGLlc/vz5856enlu3boWGhjo4OAQHB9O7xGLxs2fPCgsLu7u7GxoaFKcSEkIsLS0fP35cXV0tk8m6u7uLiopGbzoKn893dHSsra0d8kj6ga3iLEkejxceHl5QUHD06NHm5uaysrLNmzfb2dmFhISo0tv69et/+OGHzMzM5ubm3t7e2tpaOqsFBgZOnDhxGEv63b59++DBg9nZ2Ww2m6Xgyy+/JISIRKJly5ZlZ2dfunSpvb29pqaGjvOjjz5S7IQeirlz56p7dtBHFOg3f39/f39/XUcBKiGE5ObmqvWRQ4cO0TMv+Xz+ihUrMjIy6LdInJ2dq6qqsrKyhEIhIWTq1Kl3796lKCokJITNZk+ePNnIyEgoFK5cubKqqorprampadmyZTweTyQSffbZZxEREYQQsVj88OFDiqKuX78+depUY2PjxYsX19XVnT17ViAQJCQkqHuZKn4npVIpm81ua2ujNwsKCuiXbK2srLZu3ap0cEREhK+vL7Mpl8uTk5OdnZ3ZbLaFhYWfn9+dO3foXUMOUWdnZ2RkpIODg5GRkbW19erVq8vLyymK8vPzI4TExsb2G+2VK1c8PDzs7OzofxhtbW0lEsnFixcpihroVdjk5GT6s42NjaGhoWKxmMvlmpqaenh4/Pjjj0r9e3t7T548WS6Xa2RsQbdYFCbk6jd6Scz8/HxdBwJDY7FYubm5ipMpNW7Tpk35+flNTU2jd4ohqfidrKysnDVrVk5OTlBQkFbiGoJcLl+6dGlwcPCGDRu0fOqmpiZ7e/uEhITw8PDBj8Tf9zEBj2oBxpixUmpDLBbHx8fHx8crFRLRid7e3sLCQplMFhgYqP2zx8XFubm5SaVS7Z8aRgMSJwCMlqioqICAgMDAQJ2v515SUnLixImioqLBp5aOhpSUlNLS0rNnz7LZbC2fGkYJEuc49PHHHwsEAhaLpdl3C0diyHKGA1Es4kjjcDg2NjZLly5NTk5+/vz5aEeuV6Kjo3Nycl6+fCkSiY4fP67rcFSyb98+qVS6f/9+3Ybh6en53XffMQv5as3Jkyc7OztLSkosLCy0fGoYPUic49CRI0eys7N1HcX/MXg5w0EwRRzNzMwoipLL5fX19Xl5eSKRKDIycs6cOZpdhlTPJSYmdnZ2UhR1//59f39/XYejKi8vrwMHDug6Ct3w9fWNiopSfGcYxgEkTtCGwcsZqo7FYpmbmy9dujQnJycvL+/p06d0McvRiBkAoF9InOMTUxpQTwxeznB4/P39g4OD6+vrDx8+PNL4AABUhsQ5TlAUlZycPGPGDC6Xa2ZmRk/gY/RboXDIuoYXL1584403+Hy+UCicO3duc3PzQF2pS6mc4bALQ9IT/4uKivTzMgFgXELiHCdiYmIiIyNDQkKePn1aV1enVKqp3wqFg9c1bG1tXbFihb+//7NnzyoqKqZPn04vtjnyYod9yxkOuzCkm5sbIeTevXt6eIOcIjcAAAr3SURBVJkAMG7pdv0FGJIqK4m0tbXx+fx33nmHaaHvqG7cuEFRVHt7O5/PDwwMZA7mcrmffvopRVG7du0ihLS3t9O7MjIyCCGVlZUURf3xxx+EkNOnTyueaJCuVLdr167p06c3Nzer/hHm5aC+6F899eQyiforB41FWN1m9GBsxwQj3aVs0JjKysq2tjZPT89+96peoVCxrqGjo6ONjU1QUNC2bduCg4PpOkojL3ZIlzP85ZdfFMsZDltraytFUfSKa3pyme+///77778/8kvTf/r2O/q4MYbel35lIXGOB/T60XRBpb6YCoW7d+9mGpk1OQdibGxcXFy8c+fOffv2xcfHr1mzJicnZ3hdMY4dO5aSklJSUqJUmGnY7t69SwiZOXMm0ZvLDA0NdXd3V/9SxpLU1FRCyPbt23UdyDhEjy3oOSTO8YDH4xFCOjs7+93LVCgMDQ1Vq9s5c+b89NNPDQ0NKSkpBw4cmDNnDr1c2TC6IoQcOnTo559/Li4u7luYadjOnTtHCFm+fDnRm8t0d3cf1bVq9QG9kuq4v0ydwCq1YwJeDhoPXFxcDAwMLl682O/e4VUofPz48e3btwkh1tbW+/fvnz9//u3bt4fXFTVoOcNhq6urS01Ntbe3p9fs1vllAsArAolzPKBrJx0/fvzrr79ubm6+detWVlYWs3eQCoWDePz48aZNm/7888+urq4bN248ePBg0aJFw+tq8HKGhBBVCkNSFNXS0kJXZWpoaMjNzfXw8DA0NCwsLKR/49T5ZQLAq0K37ybBkFR8y04mk3388ccTJkwwNTVdvHhxbGwsIcTe3v7mzZvUABUKB69rWF1dLZFILCwsDA0NJ02atGvXrp6enoG6Gjy2IcsZDlIY8tSpU/PmzePz+RwOx8DAgPy1eNAbb7wRHx/f1NSkeLBuL5PCW7UwYhjbMQH1OPUd6vONIVqox6kP8J0cPRjbMQGPagEAANSAxAkj9eeff7IGppO6waC3zp8/HxUVpVgt7sMPP1Q8wMvLSyAQGBoazpkz5/r167qKkxAil8tTU1MlEknfXZcvX/bw8ODz+XZ2dpGRkcwL7adOnUpKShorlcZh2JA4YaRmzpw5yI8Bx44d03WAoC+++OKL9PT06OhoplrchAkTjh49eubMGeaYX375JT8/38fHp7y8fP78+boKtaKi4q233goLC+tbiqC8vNzLy8vT07OhoaGgoOA///M/N2/eTO9asWIFj8fz9PR88eKF1kMG7UHiBBgz2tvb+70B0m1XKjpw4MCxY8fy8vIUF41KT083MDAICQnRq9pwN2/e3Llz5+bNm+nFkJXs3bvX1tZ2z549JiYm7u7ukZGR33zzDbOw1LZt21xdXd97772enh7tRg3ag8QJMGZ8/fXX9fX1+taVKiorK2NiYvbs2UMv1sGQSCShoaGPHj3asWOH1oIZkqur64kTJ9atW8flcpV29fT0nDlzZsmSJcyKg8uXL6co6uTJk8wxcXFxpaWlaWlp2osYtAuJE0CrKIpKSUmZNWsWl8u1sLBYuXIlc7MilUo5HI6trS29uWXLFhMTExaL1djYSAgJDQ0NDw+vqqpisVhisTg9PZ3H49nY2GzatMnOzo7H40kkkmvXrg2jKzKCym4qSk9PpyhqxYoVfXclJCRMnz79yJEj58+f7/ezg4zYkDXjNF4e7t69ey0tLQ4ODkyLk5MTIeTWrVtMi4WFxZIlS9LS0jBnYbxC4gTQqri4uKioqF27dtXX11+6dKmmpubNN998+vQpISQ9PV1xKktGRsaePXuYzbS0NB8fHycnJ4qiKisrpVJpcHBwW1vbtm3bqqurr1+/3tPT884779TU1KjbFRlBZTcVnTlzZsaMGfSEWiXGxsbffPONgYHBxo0b6VWClQwyYoPXjCOjUB6urq6OEKL4tJnH4xkbG9PxMF577bVHjx7dvHlzJOcCvYXECaA97e3tKSkpq1atCgoKMjMzmzt37uHDhxsbGxVXelKLkZERfSs2e/bszMxMmUyWk5MzjH68vb2bm5tjYmKGF8bgWltb79+/T9+Z9cvd3X379u3V1dVKdWSJyiMmkUiEQqG1tXVgYGBra+vDhw8JIR0dHZmZmX5+fqtXrzY3N9+9ezebzR7e+DDoF2gNDQ0VG9lsdnt7u2KLs7MzIWSgpT9grEPiBNCe8vLylpaWBQsWMC0LFy7kcDjMI9aRWLBgAZ/PV6vKm3bU19dTFNXv7SYjISFhxowZGRkZly9fVmxXd8QUa8aNvApeX/RvtEov/nR1dRkbGyu20BerdBsK4wYSJ4D20LMUlFa6Nzc3l8lkGumfy+U2NDRopCsN6ujoIIT0fdFGEY/Hy8nJYbFYGzZsULx7G8mIMeXhmFnFDx486Du9RC30z8bNzc1MS1tbW0dHh1LVOTqP0hcO4w8SJ4D2mJubE0KU/tF/8eKFvb39yDvv7u7WVFeaRWeRIZcFcHd3DwsLq6io2Lt3L9M4khFjKs0pTiy+cuXKMC6BIRKJBALBgwcPmBb6R+J58+YpHtbV1UX+unAYf5A4AbTHxcXF1NRU8f2Ua9eudXV1vf766/SmkZER82KLukpKSiiKWrRo0ci70iwbGxsWi6XKTM29e/fOnDnzxo0bTMuQIzaI0SgPZ2Rk9N577126dIl5kaqoqIjFYim9MExf7MSJEzV4atAfSJwA2sPj8cLDwwsKCo4ePdrc3FxWVrZ582Y7O7uQkBD6ALFY/OzZs8LCwu7u7oaGBsU7G0KIpaXl48ePq6urZTIZnRTlcvnz5897enpu3boVGhrq4OAQHBw8jK5Uqew2bHw+39HRsba2dsgj6Qe2iq/eDDlig/c2UHm4wMDAiRMnDm9Jv5iYmKdPn37xxRetra1XrlxJTk4ODg6eMWOG4jH0xc6dO3cY/cMYMCo1V0BzUGZoDCEqlBWTy+XJycnOzs5sNtvCwsLPz+/OnTvM3qampmXLlvF4PJFI9Nlnn0VERBBCxGLxw4cPKYq6fv361KlTjY2NFy9eXFdXFxISwmazJ0+ebGRkJBQKV65cWVVVNbyuBqns1tcwvpNSqZTNZre1tdGbBQUF9Eu2VlZWW7duVTo4IiLC19dXlREbvGYcNXB5OD8/P0JIbGxsv9FeuXLFw8OD+dnS1tZWIpFcvHiROeDixYtvvPEGl8u1s7OLiIjo6OhQ6sHb23vy5Ml0+Vi14O/7mICyYvoOZYbGEC2XFdu0aVN+fn5TU5N2TscYxneysrJy1qxZOTk5QUFBoxaXGuRy+dKlS4ODgzds2KDxzpuamuzt7RMSEsLDw9X9LP6+jwl4VAswho2VQhxisTg+Pj4+Pr6lpUXXsZDe3t7CwkKZTDZKpXvi4uLc3NykUulodA76AIkTALQhKioqICAgMDBQ5+u5l5SUnDhxoqioaPCppcOTkpJSWlp69uxZNput8c5BTyBxAoxJ0dHROTk5L1++FIlEx48f13U4Ktm3b59UKt2/f79uw/D09Pzuu++YhXw16OTJk52dnSUlJRYWFhrvHPSHka4DAIDhSExMTExM1HUUavPy8vLy8tJ1FKPF19fX19dX11HAqMMdJwAAgBqQOAEAANSAxAkAAKAGJE4AAAA14OWgMaC2tjYvL0/XUYBKRriG+JhAryeH7+RoqK2t1cNl+kEJVg7SdwEBAWNlsgEAjJy/vz9WDtJzSJwAAABqwG+cAAAAakDiBAAAUAMSJwAAgBqQOAEAANTw/wBiBz48sxLnQwAAAABJRU5ErkJggg==\n",
+            "text/plain": [
+              "<IPython.core.display.Image object>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 23
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "DWPiktbUEPNl",
-        "colab_type": "code",
-        "colab": {}
+        "id": "DWPiktbUEPNl"
       },
       "source": [
         "from keras.callbacks import LearningRateScheduler\n",
         "\n",
         "annealer = LearningRateScheduler(lambda x: 1e-3 * 0.9 ** x)\n"
       ],
-      "execution_count": null,
+      "execution_count": 22,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "MdaF4lkfEPNq",
-        "colab_type": "code",
-        "colab": {}
+        "id": "MdaF4lkfEPNq"
       },
       "source": [
         "datagen = ImageDataGenerator(zoom_range = 0.2,\n",
         "                             )\n",
         "datagen.fit(x_train)"
       ],
-      "execution_count": null,
+      "execution_count": 23,
       "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "DJQNnl29d5ig",
+        "outputId": "3dc78ea0-9786-4772-ee73-21c347ec33c1"
+      },
+      "source": [
+        "x_train.shape"
+      ],
+      "execution_count": 24,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(31500, 28, 28, 1)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 24
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "WXV1cdgseZHv",
+        "outputId": "83c40bf1-92e9-403c-dbe2-c34306ddffe5"
+      },
+      "source": [
+        "batch_size = 256\n",
+        "steps_per_epoch = len(x_train)//batch_size\n",
+        "steps_per_epoch"
+      ],
+      "execution_count": 25,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "123"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 25
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
         "id": "dbBHJVDEEPNu",
-        "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "93005bac-d14e-42e9-a44f-d4bcfe81e222"
       },
       "source": [
-        "hist = model.fit_generator(datagen.flow(x_train, y_train, batch_size=256),\n",
-        "                           steps_per_epoch=600,\n",
+        "hist = model.fit(datagen.flow(x_train, y_train, batch_size=batch_size),\n",
+        "                           steps_per_epoch=steps_per_epoch,\n",
         "                           epochs=15, #Increase this when not on Kaggle kernel\n",
         "                           verbose=1,  #1 for ETA, 0 for silent\n",
-        "                           validation_data=(x_test, y_test) #For speed\n",
+        "                           validation_data=(x_test, y_test) #For test set\n",
         "                            )"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 26,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Epoch 1/15\n",
+            "123/123 [==============================] - 15s 100ms/step - loss: 0.7031 - accuracy: 0.8108 - val_loss: 2.6664 - val_accuracy: 0.1131\n",
+            "Epoch 2/15\n",
+            "123/123 [==============================] - 11s 88ms/step - loss: 0.1932 - accuracy: 0.9471 - val_loss: 1.1519 - val_accuracy: 0.6275\n",
+            "Epoch 3/15\n",
+            "123/123 [==============================] - 11s 88ms/step - loss: 0.1492 - accuracy: 0.9594 - val_loss: 0.3667 - val_accuracy: 0.8873\n",
+            "Epoch 4/15\n",
+            "123/123 [==============================] - 11s 89ms/step - loss: 0.1121 - accuracy: 0.9696 - val_loss: 0.1351 - val_accuracy: 0.9592\n",
+            "Epoch 5/15\n",
+            "123/123 [==============================] - 11s 92ms/step - loss: 0.0989 - accuracy: 0.9744 - val_loss: 0.0546 - val_accuracy: 0.9849\n",
+            "Epoch 6/15\n",
+            "123/123 [==============================] - 11s 93ms/step - loss: 0.0828 - accuracy: 0.9787 - val_loss: 0.0538 - val_accuracy: 0.9865\n",
+            "Epoch 7/15\n",
+            "123/123 [==============================] - 11s 93ms/step - loss: 0.0756 - accuracy: 0.9791 - val_loss: 0.0372 - val_accuracy: 0.9905\n",
+            "Epoch 8/15\n",
+            "123/123 [==============================] - 11s 92ms/step - loss: 0.0695 - accuracy: 0.9820 - val_loss: 0.0517 - val_accuracy: 0.9881\n",
+            "Epoch 9/15\n",
+            "123/123 [==============================] - 11s 93ms/step - loss: 0.0701 - accuracy: 0.9815 - val_loss: 0.0442 - val_accuracy: 0.9888\n",
+            "Epoch 10/15\n",
+            "123/123 [==============================] - 11s 93ms/step - loss: 0.0642 - accuracy: 0.9828 - val_loss: 0.0567 - val_accuracy: 0.9855\n",
+            "Epoch 11/15\n",
+            "123/123 [==============================] - 11s 93ms/step - loss: 0.0732 - accuracy: 0.9812 - val_loss: 0.0506 - val_accuracy: 0.9880\n",
+            "Epoch 12/15\n",
+            "123/123 [==============================] - 12s 99ms/step - loss: 0.0662 - accuracy: 0.9825 - val_loss: 0.0487 - val_accuracy: 0.9890\n",
+            "Epoch 13/15\n",
+            "123/123 [==============================] - 11s 91ms/step - loss: 0.0573 - accuracy: 0.9846 - val_loss: 0.0491 - val_accuracy: 0.9880\n",
+            "Epoch 14/15\n",
+            "123/123 [==============================] - 11s 91ms/step - loss: 0.0774 - accuracy: 0.9802 - val_loss: 0.0523 - val_accuracy: 0.9877\n",
+            "Epoch 15/15\n",
+            "123/123 [==============================] - 12s 99ms/step - loss: 0.0717 - accuracy: 0.9810 - val_loss: 0.0435 - val_accuracy: 0.9896\n"
+          ]
+        }
+      ]
     },
     {
       "cell_type": "code",
       "metadata": {
-        "trusted": true,
-        "id": "mNL2m7csEPNy",
-        "colab_type": "code",
-        "colab": {}
+        "id": "66MLiZu3m-C6"
       },
       "source": [
-        "y_pred = model.predict(test, verbose = 1)\n"
+        "import matplotlib.pyplot as plt"
       ],
-      "execution_count": null,
+      "execution_count": 29,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "dZg2UzzqnCcs",
+        "outputId": "38b3ec5f-dd31-415d-9a5c-230b1a8cec8b"
+      },
+      "source": [
+        "hist"
+      ],
+      "execution_count": 31,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<keras.callbacks.History at 0x7fc0f02d9490>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 31
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 279
+        },
+        "id": "U0wZw0GBm4Aa",
+        "outputId": "7311ff43-13a7-4792-cbdd-ebb9068f539f"
+      },
+      "source": [
+        "plt.plot(hist.history['loss'])\n",
+        "plt.plot(hist.history['val_loss'])\n",
+        "plt.legend(['Loss','Validation Loss'])\n",
+        "plt.xlabel('Epochs')\n",
+        "plt.ylabel('Cross-Entropy Loss')\n",
+        "plt.show()"
+      ],
+      "execution_count": 39,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEGCAYAAABo25JHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXxU9b3/8ddnliSEJKzBRImyuCCYBDC4lCqirVWxUne4thbt1eqv1Vqt1XtbtbX11rbcarFqr7u1LlXb4oai4oLWag2UHRdElCBgAAmBrDPz+f1xTsIQsgwkZ85M5vN8PM7jnDnnzJx3yDCfnPM98/2KqmKMMSZzBfwOYIwxxl9WCIwxJsNZITDGmAxnhcAYYzKcFQJjjMlwIb8D7KnBgwfrsGHD/I5hjDFpZcGCBZtUtbC9bWlXCIYNG0ZlZaXfMYwxJq2IyCcdbbNLQ8YYk+GsEBhjTIazQmCMMRku7doIjDHJ0dzcTFVVFQ0NDX5HMXsgJyeHoUOHEg6HE36OFQJjTLuqqqrIz89n2LBhiIjfcUwCVJXNmzdTVVXF8OHDE36eXRoyxrSroaGBQYMGWRFIIyLCoEGD9vgszgqBMaZDVgTSz978zjKnEGxcAS9eB421ficxxpiUkjmFYOsn8NYs2Ljc7yTGmATl5eX5HSEjZE4hKCpz5uuX+JvDGGNSTOYUgoJ9oc9A2LDY7yTGmG5YtGgRRx11FGVlZZx++ul88cUXAMyaNYvRo0dTVlbGtGnTAHj99dcZO3YsY8eOZdy4cdTW2qXh9mTO7aMiUFxmZwTG7IWfP7OcFZ9t69HXHL1vATd8fcweP+/888/ntttuY9KkSVx//fX8/Oc/59Zbb+Xmm2/m448/Jjs7m61btwIwc+ZMbr/9diZOnMj27dvJycnp0Z+ht8icMwJwLg99vhIiTX4nMcbshZqaGrZu3cqkSZMA+Pa3v838+fMBKCsr47zzzuPPf/4zoZDzN+7EiRO58sormTVrFlu3bm1db3aVWf8qxeUQa4bq95yzA2NMQvbmL/dke+6555g/fz7PPPMMN910E0uXLuXaa69lypQpzJkzh4kTJzJ37lxGjRrld9SUk3lnBAAb7PKQMemoX79+DBgwgDfeeAOAhx56iEmTJhGLxVi7di2TJ0/m17/+NTU1NWzfvp2PPvqI0tJSrrnmGiZMmMB7773n80+QmjLrjGDQSAjnwoalficxxiSgrq6OoUOHtj6+8sorefDBB7nkkkuoq6tjxIgR3H///USjUb75zW9SU1ODqnL55ZfTv39/rrvuOl599VUCgQBjxozh5JNP9vGnSV2ZVQgCQdjnMGswNiZNxGKxdte//fbbu6178803d1t322239Xim3iizLg2B0zawYSl08AYzxphM41khEJESEXlVRFaIyHIR+UE7+xwnIjUissidrvcqT6uiUmiqhS8+9vxQxhiTDry8NBQBrlLVhSKSDywQkZdUdUWb/d5Q1VM9zLGr+AbjQSOTdlhjjElVnp0RqOp6VV3oLtcCK4H9vDpewoaMBglaO4ExxriS0kYgIsOAccA77Ww+WkQWi8jzItLuzcoicrGIVIpIZXV1dffChHOgcJTdQmqMMS7PC4GI5AF/Ba5Q1bbfUV8IHKCq5cBtwOz2XkNV71LVClWtKCws7H6olgZjY4wx3hYCEQnjFIGHVfVvbber6jZV3e4uzwHCIjLYy0yA006wfSPUbvT8UMaYvTN58mTmzp27y7pbb72VSy+9tMPnHHfccVRWVgJwyimntPY5FO9nP/sZM2fO7PTYs2fPZsWKnc2Z119/PS+//PKexG/Xa6+9xqmnJq9JNFFe3jUkwL3ASlX9XQf7FLn7ISJHuHk2e5WpVbF9w9iYVDd9+nQee+yxXdY99thjTJ8+PaHnz5kzh/79++/VsdsWghtvvJGvfOUre/Va6cDLM4KJwLeA4+NuDz1FRC4RkUvcfc4ClonIYmAWME1V1cNMjqJSZ77euqQ2JlWdddZZPPfcczQ1OZ1Erlmzhs8++4xjjjmGSy+9lIqKCsaMGcMNN9zQ7vOHDRvGpk2bALjppps4+OCD+fKXv8z777/fus/dd9/NhAkTKC8v58wzz6Suro633nqLp59+mquvvpqxY8fy0UcfMWPGDJ588kkA5s2bx7hx4ygtLeXCCy+ksbGx9Xg33HAD48ePp7S0dI+6s3j00UcpLS3lsMMO45prrgEgGo0yY8YMDjvsMEpLS7nllluA9rvb7i7Pbh9V1TeBTgfPVNU/AH/wKkOHcvrBgGF2RmBMop6/tufb1YpK4eSbO9w8cOBAjjjiCJ5//nmmTp3KY489xjnnnIOIcNNNNzFw4ECi0SgnnHACS5Ysoays/Y4kFyxYwGOPPcaiRYuIRCKMHz+eww8/HIAzzjiDiy66CICf/vSn3HvvvVx22WWcdtppnHrqqZx11lm7vFZDQwMzZsxg3rx5HHzwwZx//vnceeedXHHFFQAMHjyYhQsXcscddzBz5kzuueeeLv8ZPvvsM6655hoWLFjAgAEDOPHEE5k9ezYlJSWsW7eOZcuWAbRe5mqvu+3uyrxvFrcoKrVbSI1JcfGXh+IvCz3++OOMHz+ecePGsXz58l0u47T1xhtvcPrpp5Obm0tBQQGnnXZa67Zly5ZxzDHHUFpaysMPP8zy5Z0PZfv+++8zfPhwDj74YGDXbrDBKSwAhx9+OGvWrEnoZ3z33Xc57rjjKCwsJBQKcd555zF//nxGjBjB6tWrueyyy3jhhRcoKCgA2u9uu7syq6+heEXlsPIZaKhxzhCMMR3r5C93L02dOpUf/vCHLFy4kLq6Og4//HA+/vhjZs6cybvvvsuAAQOYMWMGDQ0Ne/X6M2bMYPbs2ZSXl/PAAw/w2muvdStvdnY2AMFgkEgk0q3XGjBgAIsXL2bu3Ln88Y9/5PHHH+e+++5rt7vt7haEzD0jaG0wXuZvDmNMh/Ly8pg8eTIXXnhh69nAtm3b6Nu3L/369WPjxo08//zznb7Gsccey+zZs6mvr6e2tpZnnnmmdVttbS3FxcU0Nzfz8MMPt67Pz89vd1jLQw45hDVr1rBq1SpgZzfY3XHEEUfw+uuvs2nTJqLRKI8++iiTJk1i06ZNxGIxzjzzTH75y1+ycOHCDrvb7q4MPiNoKQRLYdhEf7MYYzo0ffp0Tj/99NZLROXl5YwbN45Ro0ZRUlLCxImd//8dP3485557LuXl5QwZMoQJEya0bvvFL37BkUceSWFhIUceeWTrh/+0adO46KKLmDVrVmsjMUBOTg73338/Z599NpFIhAkTJnDJJZfsdszOzJs3b5eutZ944gluvvlmJk+ejKoyZcoUpk6dyuLFi7ngggtae2D91a9+1WF3290lybhJpydVVFRoy33C3aIKMw+Cg06Eb9zR/dczppdZuXIlhx56qN8xzF5o73cnIgtUtaK9/TP30pCIc1ZgDcbGmAyXuYUAnHaC6pUQafQ7iTHG+CazC0FRGcQi8PlKv5MYk5LS7dKx2bvfmRUCsC+WGdOOnJwcNm/ebMUgjagqmzdvJicnZ4+el7l3DQEMHAFZedZOYEw7hg4dSlVVFd3u+t0kVU5Ozi53JSUiswtBIOAMZm9nBMbsJhwOM3z4cL9jmCTI7EtD4I5NsMwGszfGZCwrBEVl0LwDtqz2O4kxxvjCCkFrVxPWJbUxJjNZISg8FAJhazA2xmQsKwShLBhig9kbYzKXFQJwuqRev8Tpf8gYYzKMFQJwBqmp2wS16/1OYowxSWeFAHY2GFs7gTEmA1khAOdLZdDzY7IaY0wasEIAkFPgdDdht5AaYzKQFYIWNjaBMSZDWSFoUVwGWz+B+q1+JzHGmKSyQtCiqNyZWzuBMSbDWCFoUWxjExhjMpMVghZ5QyBvH2snMMZkHCsE8YrK7NKQMSbjWCGIV1wG1e9Bc4PfSYwxJmk8KwQiUiIir4rIChFZLiI/aGcfEZFZIrJKRJaIyHiv8iSkqAw0Cp+v8DWGMcYkk5dnBBHgKlUdDRwFfE9ERrfZ52TgIHe6GLjTwzxdswZjY0wG8qwQqOp6VV3oLtcCK4H92uw2FfiTOt4G+otIsVeZutR/GGQXWIOxMSajJKWNQESGAeOAd9ps2g9YG/e4it2LBSJysYhUikhldXW1VzGdweyLSu2MwBiTUTwvBCKSB/wVuEJVt+3Na6jqXapaoaoVhYWFPRuwraIy2LgcYlFvj2OMMSnC00IgImGcIvCwqv6tnV3WASVxj4e66/xTVArNdbB5la8xjDEmWby8a0iAe4GVqvq7DnZ7GjjfvXvoKKBGVf0dHaa1wdi+T2CMyQxdFgIR+YGIFLgf1veKyEIROTGB154IfAs4XkQWudMpInKJiFzi7jMHWA2sAu4G/t/e/iA9pnAUBLNgvXVJbYzJDKEE9rlQVX8vIl8DBuB8uD8EvNjZk1T1TUC62EeB7yWYNTmCYRhyqDUYG2MyRiKXhlo+zE8BHlLV5XTxAZ/2WsYmsMHsjTEZIJFCsEBEXsQpBHNFJB+IeRvLZ8XlUL8Ftvnbbm2MMcmQyKWh7wBjgdWqWiciA4ELvI3ls6K4wez7DfU3izHGeCyRM4KjgfdVdauIfBP4KVDjbSyf7TMGEGsnMMZkhEQKwZ1AnYiUA1cBHwF/8jSV37LzYNCB1tWEMSYjJFIIIu7dPVOBP6jq7UC+t7FSQFGpfZfAGJMREikEtSLyXzi3jT4nIgEg7G2sFFBcBjWfQt0Wv5MYY4ynEikE5wKNON8n2IDTDcRvPU2VCorsG8bGmMzQZSFwP/wfBvqJyKlAg6r27jYCcG4hBWswNsb0eol0MXEO8C/gbOAc4B0ROcvrYL7rOxjy97UGY2NMr5fI9wh+AkxQ1c8BRKQQeBl40stgKaG4zM4IjDG9XiJtBIGWIuDanODz0l9RGWz6AJrq/E5ijDGeSeSM4AURmQs86j4+F3jeu0gppLgMNOYMZj+0wu80xhjjiS4LgapeLSJnAF92V92lqn/3NlaKKCp15huWWCEwxvRaiZwR4I4u1jrCmIh8qqr7e5YqVfQ/AHL6WYOxMaZX29tr/b27G+oWIk47gTUYG2N6sb0tBJnTUX/LYPbRiN9JjDHGEx1eGhKRKzvaBOR5EycFFZdBpAE2f+iMXGaMMb1MZ20EnXUs9/ueDpKy4scmsEJgjOmFOiwEqvrzZAZJWYMPhlCO005Qfq7faYwxpsdlxhfDuiMYgiGjrcHYGNNrWSFIRLENZm+M6b0S6XQumIwgKa2oFBq2Qs1av5MYY0yPS+SM4EMR+a2IjPY8Taoqcrukti+WGWN6oUQKQTnwAXCPiLwtIheLSIHHuVLLPmNAAtZOYIzplRIZmKZWVe9W1S8B1wA3AOtF5EEROdDzhKkgKxcGHWRnBMaYXimhNgIROU1E/g7cCvwvMAJ4Bpjjcb7UYWMTGGN6qUQ6nfsQeBX4raq+Fbf+SRE51ptYKaioDJY+ATs2Q99Bfqcxxpgek0ghKFPV7e1tUNXLezhP6ipuGcx+CYyc7G8WY4zpQYk0Fg8RkWdEZJOIfC4iT4nIiK6eJCL3ufsv62D7cSJSIyKL3On6PU6fTEVxhcAYY3qRRArBI8DjQBGwL/AEO0cr68wDwEld7POGqo51pxsTeE3/5A6EgqHWYGyM6XUSKQS5qvqQqkbc6c9ATldPUtX5wJZuJ0wl1mBsjOmFEikEz4vItSIyTEQOEJEfA3NEZKCIDOzm8Y8WkcUi8ryIjOloJ/e7C5UiUlldXd3NQ3ZDURls+hCadviXwRhjelgijcXnuPPvtlk/DWeAmi7bCzqwEDhAVbeLyCnAbOCg9nZU1buAuwAqKir86/CnuAxQZ6CakiN8i2GMMT0pkcHrh3txYFXdFrc8R0TuEJHBqrrJi+P1iNaxCRZbITDG9BpdFgIRCQOXAi3fGXgN+D9Vbe7OgUWkCNioqioiR+Bcptrcndf0XL+h0GeAtRMYY3qVRC4N3QmEgTvcx99y1/1nZ08SkUeB44DBIlKF0zVFGEBV/wicBVwqIhGgHpimmuL9PLcOZr/U7yTGGNNjEikEE1S1PO7xKyKyuKsnqer0Lrb/AfhDAsdPLcVl8M5dEG2GYNjvNMYY022J3DUUFZGRLQ/cL5NFvYuU4orKINoImz7wO4kxxvSIRM4IfgS8KiKrAQEOAC7wNFUqix/Mfp8O73g1xpi00WkhcEcnK8e5rfMQd/X7qtrodbCUNfggCPVxG4w7vfpljDFpodNLQ6oaBaaraqOqLnGnzC0CAIGgcyZgXU0YY3qJRC4N/UNE/gD8BWj9Sq2qLvQsVaorLoOlf3UGsxfxO40xxnRLIoVgrDuP7xROgeN7Pk6aKCqDyvvgizUw0JPv2xljTNIkUgi+o6qr41ck0g11r9Y6NsFSKwTGmLSXyO2jT7az7omeDpJWhowBCdo3jI0xvUKHZwQiMgoYA/QTkTPiNhWQQDfUvVo4BwoPsQZjY0yv0NmloUOAU4H+wNfj1tcCF3kZKi0UlcLH8/1OYYwx3dZhIVDVp4CnRORoVf1nEjOlh6IyWPIX2F4NeYV+pzHGmL2WSGPxKhH5b2BY/P6qeqFXodJCa4PxYjjwK/5mMcaYbkikEDwFvAG8TCb3MdRWUakzX7/ECoExJq0lUghyVfUaz5Okmz4DoP/+1iW1MSbtJXL76LPuUJKmrSIbzN4Yk/4SKQQ/wCkG9SKyTURqRWRbl8/KBMXlsPkjaNzudxJjjNlrXRYCVc1X1YCq9lHVAvdxQTLCpbyilsHsl/mdxBhj9lqHhUBEvhm3PLHNtu97GSptxDcYG2NMmursjODKuOXb2mzL7FtHWxTsC7mDnFtIjTEmTXVWCKSD5fYeZ6aWweztjMAYk8Y6KwTawXJ7jzPX/kc7t5DWrPM7iTHG7JXOCsEoEVkiIkvjllseH9LJ8zJL2dmAwtLH/U5ijDF7pbMvlB2atBTpbOAIKDkKFj8GE6+wEcuMMWmnwzMCVf2k7QSUxi2bFuXToPo9+Ozfficxxpg9lsgXyuLd2PUuGWjM6RDMds4KjDEmzexpIbDrHu3p0x9GnQLLnoRIk99pjDFmj+xpIfiuJyl6g/LpULcZVr3kdxJjjNkjXRYCETlbRPLdh18Tkb+JyHiPc6WfkSdA30JY/KjfSYwxZo8kckZwnarWisiXgeOBe4E7u3qSiNwnIp+LSLsd8Yhjloiscm9LTe/iEgxB6Tnw/gtQt8XvNMYYk7BECkHLYDRTgLtV9TkgK4HnPQCc1Mn2k4GD3OliEiguKa98GsSaYdlf/U5ijDEJS6QQrBOR/wPOBeaISHYiz1PV+UBnfxpPBf6kjreB/iJSnEjolFVUCkPG2N1Dxpi0kkghOAeYC3xNVbcCA4Gre+DY+wFr4x5XuevSlwiMnQ7rKmHTh36nMcaYhCRSCIqB51T1QxE5Djgb+JenqdoQkYtFpFJEKqurq5N56D1XejZIwM4KjDFpI5FC8FcgKiIHAncBJcAjPXDsde5rtRjqrtuNqt6lqhWqWlFYWNgDh/ZQfhGMPB6W/AViMb/TGGNMlxIpBDFVjQBnALep6tU4Zwnd9TRwvnv30FFAjaqu74HX9V/5dKhZC5+86XcSY4zpUmedzrVoFpHpwPnA19114a6eJCKPAscBg0WkCrih5Xmq+kdgDnAKsAqoAy7Y0/Apa9QUyC5wLg8NP9bvNMYY06lECsEFwCXATar6sYgMBx7q6kmqOr2L7Qp8L6GU6SbcB0ZPheV/h1N+C1l9/U5kjDEdSuQ20BXAj4ClInIYUKWqv/Y8Wbornw5N22Hls34nMcaYTiXSxcRxwIfA7cAdwAciYtc7urL/0dD/AOtywhiT8hJpLP5f4ERVnaSqxwJfA27xNlYvEAg43zRe/Rps+8zvNMYY06FECkFYVd9veaCqH5BAY7EBys4F1LmV1BhjUlQihWCBiNwjIse5091ApdfBeoVBI3cOY6nqdxpjjGlXIoXgEmAFcLk7rQAu9TJUr9IyjOX6RX4nMcaYdnVaCEQkCCxW1d+p6hnudIuqNiYpX/ob8w1nGMtF1mhsjElNnRYCVY0C74vI/knK0/v0GQCHnGzDWBpjUlYil4YGAMtFZJ6IPN0yeR2sVxn7H+4wli/7ncQYY3aTyDeLr/M8RW838nh3GMtHnEHujTEmhXRYCNzeRvdR1dfbrP8y0Ds6h0uWYNjpnvpfdzvDWOYO9DuRMca06uzS0K3AtnbW17jbzJ4on+4MY7n8b34nMcaYXXRWCPZR1aVtV7rrhnmWqLeyYSyNMSmqs0LQv5NtfXo6SK8n4nynoOpdG8bSGJNSOisElSJyUduVIvKfwALvIvViZefYMJbGmJTT2V1DVwB/F5Hz2PnBXwFkAad7HcwLDc1RcsJB/wLED2M5+SdOx3TGGOOzDj+JVHWjqn4J+Dmwxp1+rqpHq+qG5MTrOXOXb+BLN7/Cuq31/gaxYSyNMSkmkYFpXlXV29zplWSE8sJh+/VjR2OE37zwnr9BDjkFsvLt8pAxJmVkzLWJ/fr34aJjRvDUos/496df+BckK9fpf2jFU9C0w78cxhjjyphCAHDpcSMpzM/mxmdXoH52C90yjOV7z/mXwRhjXBlVCPpmh7j6a4fw70+38vRiH0cN2/9o6L8/LHrEvwzGGOPKqEIAcNb4oYzZt4BfP/8eDc1Rf0IEAlBmw1gaY1JDxhWCQEC47tTRfFbTwD1vrPYvSPk0nGEsH/cvgzHGkIGFAOCoEYP42ph9uOO1j/h8W4M/IQaNhJIjYfGjNoylMcZXGVkIAP7r5ENpjsaY+eL7/oWwYSyNMSkgYwvBsMF9uWDicJ5YUMWydTX+hBhzujOMpX2nwBjjo4wtBADfP/5ABuRm8Qu/bidtGcZy6RM2jKUxxjcZXQgKcsL88KsH887HW5i7fKM/Icqn2zCWxhhfZXQhAJg+oYSD98njV8+vpDHiw+2kB57gDmP5aPKPbYwxeFwIROQkEXlfRFaJyLXtbJ8hItUissid/tPLPO0JBQP8ZMpoPtlcx5/e+iTZh985jOUHLzjDWBpjTJJ5VghEJAjcDpwMjAami8jodnb9i6qOdad7vMrTmUkHFzL5kEJmzfuQzdsbkx+gfBpEm2wYS2OML7w8IzgCWKWqq1W1CXgMmOrh8brlJ1MOpa45yi0vf5D8gxeVwZDRdveQMcYXXhaC/YC1cY+r3HVtnSkiS0TkSREpae+FRORiEakUkcrq6movsnLgkHy+eeT+PPLOp3ywsdaTY3RIxGk0rnoXNq1K7rGNMRnP78biZ4BhqloGvAQ82N5OqnqXqlaoakVhYaFnYa74ysHkZYf45XMrPTtGh0rPdoextEZjY0xyeVkI1gHxf+EPdde1UtXNqtpyUf4e4HAP83RpQN8sLj/hIOZ/UM2r73+e3IMXFMOIyc4wlrFYco9tjMloXhaCd4GDRGS4iGQB04Cn43cQkeK4h6cBPvwpvqvzjx7G8MF9+eWzK2iOJvkDeex/uMNY/iO5xzXGZDTPCoGqRoDvA3NxPuAfV9XlInKjiJzm7na5iCwXkcXA5cAMr/IkKisU4L9POZSPqnfwyDufJvfgNoylMcYH4utIXXuhoqJCKysrPT2GqnLePe+wYv02Xv/RZPrlhj093i6e+h4snw0/+gCy+ibvuMaYXk1EFqhqRXvb/G4sTkkiwk+njKamvplZr3yY3IPbMJbGmCSzQtCB0fsWcG5FCQ++tYbV1duTd+D9v+QMY2l3DxljksQKQSeuOvEQcsJB/mfOe8k7qA1jaYxJMisEnSjMz+b/TR7Jyys38taqTck7cPk00BhU3p+8YxpjMpYVgi5cOHE4Qwf04cZnVxCNJalhfdBI5w6i+b+BF6+DmA+9ohpjMoYVgi7khINce/Io3ttQyxOVa7t+Qk85+0GouBDemgV/PtN6JjXGeMYKQQKmlBZTccAAZr74AbUNzck5aCgLTr0Fvj7L+YLZ3ZNhw7LkHNsYk1GsECRARLju1NFs2t7IHa99lNyDH/5tmDEHmhvg3q/CMuuq2hjTs6wQJKi8pD9njNuPe9/8mLVb6pJ78JIJ8N3XoagUnrwAXrrB2g2MMT3GCsEeuPqkQwgI3PxCEm8nbZFfBN9+Fg6/AP5xKzx8trUbGGN6hBWCPVDcrw/fPXYkzy1ZT+UaHz6EQ1nw9Vvh67+Hj+c77QYblyc/hzGmV7FCsIe+O2kE+xRk84tnVxBL1u2kbR0+Ay5w2w3u+Sos/7s/OYwxvYIVgj2UmxXimpNGsbiqhtmL1nX9BK+UHAEXvwb7jIEnZsDLP7N2A2PMXrFCsBe+MXY/yob24zcvvE9dU8S/IAXFMONZ5wzhzVvgkXOg/gv/8hhj0pIVgr0QCDi3k27Y1sBd81f7GyaU7bQZnHorrH4d7poMG1f4m8kYk1asEOylCcMGMqW0mP97fTUbahr8jgMVF8CM56C5Du75Cqx4yu9Expg0YYWgG649eRTRmHLVE4v464Iq/v3pF9TUJ+mbx+3Z/0i4+HXYZzQ8fj7Mu9HaDYwxXQr5HSCdlQzM5eqvHcKvX3iPf6za3Lp+cF4WIwbnMXxwX0YU9mVEYR4jCvuy/8BcwkGPa29BsXNmMOdH8Mb/wvolcOY90Ke/t8c1xqQtG6qyBzRHY3y6pY7V1TtYXb3dmW9y5pt3NLXuFwoI+w/M3VkcBu8sEoP6ZiEiPRus8j6Y82PoXwLTHoEhh/bs6xtj0kZnQ1VaIfBYTV0zH7lFIb5IrNlUR1M01rpfQU6otSiMLHTOJg4YlEvJwFwKcroxZvKnb8NfvuW0HXzjThh9Wg/8VMaYdGOFIAVFY8q6L+rbLRIbtzXusm+/PmFKBvahZIBTGEoG9GHogFxKBjrznHCw84Nt+8wpBusq4ZgfwaQfO3cbGWMyhhWCNLO9McLH1Tv4dEsda7+oY+2WOtZ+UU/VljqqttbTFIntsn9hfjYlA/q4RSKXoXHLxf1znHaJSCM8dxX8+yEI58KwY+DAE2DkCc5AOD19WcoYk1KsEPQisZhSvb3RLQ51rN1ST5U7X/tFHetrGnYZSS0YEIoKchmkszMAAA0/SURBVJwziv59+JIsYVTNGwzd8k/y65yBdhryStgxdBJNwycTGD6JnPz+9M0KEvK6YdsYkzRWCDJIJBpjfU0Da7fUUfVF/S5nFGu31PF57c7LTvvLRo4NLGFSYDFfCiynrzTSrEEW6kG8Hi3jnzKWNeGR5GZnkZsVdKcQfbOdedvHeTkh8rND5GWHyM9peRx25jkh7++YMsZ0yAqBadUUibGjMcKOpgh1TVFnaoxQV19PzoZKBq5/gyHV/2BwrdPV9vZQfz7IrWBJnwoWhMazIZrf+rwdjRHqm6LsaIqQSP972aGAUyCyQ+TnhMnLDrUWiXx3OS877Dx29+uTFSQ7FCAcDJDVMo9bDgfFWQ4ECATs8pYxHbFCYPbc9s/ho1dg1TxnXrfJWV9U6rQrHHgClBwFoSxUlYbmGNsbI2xvjFDb0Mz2hgi1jRFn3tDsrG997OzXsk/r9obILpe19lQoIHEFIuAWkF3XZYWcQhIOCiF3Hg4GCAXiloNCljsPBZznhALSWnhCwZ1FqO3zBEFxfob4/1otiy3/37TNhnafE7ccas3pHL8lX0uGlu0tOcKBlvyS8G3JsZjSFI3R2ByjMRKlMRI/b7s+RmNz3HIk6m6PERDiCrfsVsTjC3hWMEA4rqhnx/2udi364tulSlVle2OErXXN1NQ375zXN8Wta9plW1Mk1vr+acne8h5quz4c9/uK/x3v+rt1lstL+nH4AQP36uewQmC6JxaDDUvgo3lOYVj7DsQikJW3s9H5gC9BKCeu0VncZUl4naI0RpTapgg7GmPsaIqyozlAQ6APzTHn+xqNkRjNUaUpEqM5GotbF4tbp+2s23W/SExb5xH3OS37RaJKc8xZ153ClApCRMgPNJEfbKIg2ER+oIk8aSI/0EiAGPVRoT4aoC4apD4qNBNypyARQjRrkGZCRAjS5M4jBIH2i0s4KKhCxIN/t2DAKRRZIafIZ4ecs8XscNxy6/b2tgXJDjvFpWW9ANsamnf/QK9vpqbOndc3d/o+yAkH6NcnTP8+WfTLDdOvT5jsUIBIVIm476PWedR5z7W831ree5GY+76Ltrwnnfdg24/nS48byTUnjdqrf7/OCoF9s9h0LRCAfcc60zFXQcM2WPOGUxRWvQwfPN8jhxEgx50K227JznenAmeeU7D7cl6Buxy/X7+dy+Gc9g8cbYbGWmjaDo3bnbm7HGusJdpQizbUEmvcQayx1tnX3U+adiDN25Gm7QQi9agE0EAWGswi5s41mIUGwsSCWa3b1F2OBcMQzCYWyIJg2JmHdj6XYDYxBG2ug6Y6pLkOmnYgzXVI8w4CkXoCkTqC7jwUqScYrSccrSMUrSeobXrHbbnhLL7nEcH5JNiDTwMNhNFACIJObgmGnXkgDIGg8++AOHOl9XEMcdYTIIYQU3YuAzECxFRQIKrirhdiKsRUicXUmbvLGlFizRq3DVRjxNQ5w1F3X3Wn3d9zSjExghIjHFCyAhAOKGFRZx5WQlkxQqIERQkSI+ikdCdFNOp05dIQg7ooaAwk4NyiHcpxBpQK5TiPs915MDtue077+4ZyiAWziQSc90M0kIUM9qbLGCsEZs/lFMCoKc6kCltWw2f/ds4SWv+zqbvccu1D92Bd3Dza6HzwNmxzP4BrnOW6LfDFmp3bIvVd5w5m7SwSGt35oR9t6vApAeI65JIgZOdBVr477wu5eZBd5JwdZeU6HwjRJmeKNMYtN0F0BzR94a5rdNfF79vYYY5df45s51hZec6twFm50KcvZA1yH/fdOW9dzoVwX3fubguEIdbsZmh2plhzJ8tNEI1ArBmJNiEd7ReLIup85DtVIBY3j7m/81jcFLffLtva7LfLJS53ub11retll/XqnnXGFLdgOJfkQqEQwWAICQSd33Eg6HyQxy+3bItfDgTaWec+1pjzO4007JxHm3Y+bqyN2960636xnf2VBYCs+N/9l38I+41J7H2yBzwtBCJyEvB7IAjco6o3t9meDfwJOBzYDJyrqmu8zGR6mIjzPYRBI/3N0fJXfUONWzC2xRWPbXGP3XWtH+p94z7Y83bO45ez8539drn05QFVp5juUkAanaIVzt05Be3vt73RUhpS/t61WHTnHwZti0nuIE8O6dk7SkSCwO3AV4Eq4F0ReVpV4zvL/w7whaoeKCLTgF8D53qVyfRiwTDkDnSmdCXi/BzBbnQpYtJfIOicuZGbvEN6+NpHAKtUdbWqNgGPAVPb7DMVeNBdfhI4QXq85zVjjDGd8bIQ7AesjXtc5a5rdx9VjQA1wG7nPiJysYhUikhldXW1R3GNMSYzpfzlMgBVvUtVK1S1orCwsOsnGGOMSZiXhWAdUBL3eKi7rt19RCQE9MNpNDbGGJMkXhaCd4GDRGS4iGQB04Cn2+zzNPBtd/ks4BVNt2+4GWNMmvPsriFVjYjI94G5OLeP3qeqy0XkRqBSVZ8G7gUeEpFVwBacYmGMMSaJPL0hWVXnAHParLs+brkBONvLDMYYYzqXFo3FxhhjvJN2nc6JSDXwyV4+fTCwqQfjeC2d8qZTVkivvOmUFdIrbzplhe7lPUBV273tMu0KQXeISGVHve+lonTKm05ZIb3yplNWSK+86ZQVvMtrl4aMMSbDWSEwxpgMl2mF4C6/A+yhdMqbTlkhvfKmU1ZIr7zplBU8yptRbQTGGGN2l2lnBMYYY9qwQmCMMRkuYwqBiJwkIu+LyCoRudbvPB0RkRIReVVEVojIchH5gd+ZEiEiQRH5t4g863eWzohIfxF5UkTeE5GVInK035k6IyI/dN8Hy0TkURHpYOBlf4jIfSLyuYgsi1s3UEReEpEP3fkAPzO26CDrb933whIR+buI9PczY7z28sZtu0pEVEQG98SxMqIQxI2WdjIwGpguIqP9TdWhCHCVqo4GjgK+l8JZ4/0AWOl3iAT8HnhBVUcB5aRwZhHZD7gcqFDVw3D67Eq1/rgeAE5qs+5aYJ6qHgTMcx+nggfYPetLwGGqWgZ8APxXskN14gF2z4uIlAAnAp/21IEyohCQ2GhpKUFV16vqQne5FueDqu2APilFRIYCU4B7/M7SGRHpBxyL09khqtqkqlv9TdWlENDH7aY9F/jM5zy7UNX5OB1GxosfefBB4BtJDdWB9rKq6ovuoFgAb+N0l58SOvi3BbgF+DHQY3f6ZEohSGS0tJQjIsOAccA7/ibp0q04b8yY30G6MByoBu53L2PdIyJ9/Q7VEVVdB8zE+ctvPVCjqi/6myoh+6jqend5A7CPn2H2wIXA836H6IyITAXWqerinnzdTCkEaUdE8oC/Aleo6ja/83RERE4FPlfVBX5nSUAIGA/cqarjgB2kzmWL3bjX1qfiFLB9gb4i8k1/U+0Zd3yRlL9HXUR+gnNZ9mG/s3RERHKB/wau72rfPZUphSCR0dJShoiEcYrAw6r6N7/zdGEicJqIrMG55Ha8iPzZ30gdqgKqVLXlDOtJnMKQqr4CfKyq1araDPwN+JLPmRKxUUSKAdz55z7n6ZSIzABOBc5L8YGxRuL8UbDY/f82FFgoIkXdfeFMKQSJjJaWEkREcK5hr1TV3/mdpyuq+l+qOlRVh+H8u76iqin5V6uqbgDWisgh7qoTgBU+RurKp8BRIpLrvi9OIIUbt+PEjzz4beApH7N0SkROwrmseZqq1vmdpzOqulRVh6jqMPf/WxUw3n1fd0tGFAK3MahltLSVwOOqutzfVB2aCHwL5y/rRe50it+hepHLgIdFZAkwFvgfn/N0yD1zeRJYCCzF+f+aUl0iiMijwD+BQ0SkSkS+A9wMfFVEPsQ5q7nZz4wtOsj6ByAfeMn9v/ZHX0PG6SCvN8dK7TMhY4wxXsuIMwJjjDEds0JgjDEZzgqBMcZkOCsExhiT4awQGGNMhrNCYIxLRKJxt+wu6sleakVkWHu9SBqTCkJ+BzAmhdSr6li/QxiTbHZGYEwXRGSNiPxGRJaKyL9E5EB3/TARecXty36eiOzvrt/H7dt+sTu1dAsRFJG73fEFXhSRPu7+l7vjTywRkcd8+jFNBrNCYMxOfdpcGjo3bluNqpbifBP1VnfdbcCDbl/2DwOz3PWzgNdVtRynL6OWb7EfBNyuqmOArcCZ7vprgXHu61zi1Q9nTEfsm8XGuERku6rmtbN+DXC8qq52OwTcoKqDRGQTUKyqze769ao6WESqgaGq2hj3GsOAl9zBWhCRa4Cwqv5SRF4AtgOzgdmqut3jH9WYXdgZgTGJ0Q6W90Rj3HKUnW10U3BG0BsPvOsOQmNM0lghMCYx58bN/+kuv8XOoSPPA95wl+cBl0LrWM79OnpREQkAJar6KnAN0A/Y7azEGC/ZXx7G7NRHRBbFPX5BVVtuIR3g9ljaCEx3112GM9rZ1Tgjn13grv8BcJfbW2QUpyisp31B4M9usRBgVhoMn2l6GWsjMKYLbhtBhapu8juLMV6wS0PGGJPh7IzAGGMynJ0RGGNMhrNCYIwxGc4KgTHGZDgrBMYYk+GsEBhjTIb7/9BKszboKEmVAAAAAElFTkSuQmCC\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 279
+        },
+        "id": "qrt_v0Y2nril",
+        "outputId": "a6bc1ef4-ed04-40ed-ab72-fce2c8812da3"
+      },
+      "source": [
+        "plt.plot(hist.history['accuracy'])\n",
+        "plt.plot(hist.history['val_accuracy'])\n",
+        "plt.legend(['Accuracy','Validation Accuracy'])\n",
+        "plt.xlabel('Epochs')\n",
+        "plt.ylabel('Accuracy')\n",
+        "plt.show()"
+      ],
+      "execution_count": 38,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEGCAYAAABo25JHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deZwU1b338c+vezaGfRNQRiEuCAijQtSgcU/UiOCOJCZBDUYTcUm8T7wxN1ejuTdP9CbqjY+RxMRodEBcEBOVKItL1MhAZgARlQjKIOjIzmw93X2eP6pmaIaZoYHpqZ6p7/v16ldXnaqu/k3TnF/XOVXnmHMOEREJr0jQAYiISLCUCEREQk6JQEQk5JQIRERCTolARCTkcoIOYG/169fPDRkyJOgwREQ6lMWLF3/unOvf3LYOlwiGDBlCaWlp0GGIiHQoZvZRS9vUNCQiEnJKBCIiIadEICISchlLBGb2BzP7zMyWt7DdzOw+M1tlZkvN7NhMxSIiIi3L5BnBw8DZrWw/Bzjcf1wNPJDBWEREpAUZSwTOuVeBTa3sMhF4xHneAnqZ2aBMxSMiIs0Lso/gIGBtynqFX7YbM7vazErNrLSysrJdghMRCYsOcR+Bc246MB1g7NixGjdbdpVMQn011NdAfZX3HKtOWa7auT3ml1kEcvIg2vSRCzn5O5ej+a2U53rrOfkQyQGzXeNyznvgwCWbPJqWtbKfGeQU7HxEO8R/250aPgeXgGTC/7v852Ri57bG9dTtKZ+FRbxHJAIW9Zf958b1SJP11O22+79Re38OyQQk6yERg0TcX673n1PX4ynlKesDj4LeQ9o8tCC/UeuAopT1wX6ZdDRVG6FypfelTcb9L3Qzj4YvdMN/hsbyVvZPxJqpyJtU6vGaoD8BTyTXe26ouMjQb5ZIDuR08RJQrv+c0wVyU5JF4zZ/PXVbw2sw7/ON1/mfdZ2/HvMrqrqU5VjKvrHd90vU7zxOMr5rZe6Smfkc9oGznYnCWQTwkoM1JgnDMDAat3l2bm+2DHbd3ljhN6ns99e5v4IvXrX/x2kiyEQwB7jOzGYAxwNbnXPrA4xH0hWrho/fhA8Xeo8Ny9jvSs+iXgUXyfF+8TYu50NeIeT6j24H7FzOK/Qqtdyuu+6Tutx0Pa/QqzRxuHgdsVgdsboaYnV1xGK11NfVEq+voz5WR7yuhkR9jHh9Hcn6OhLxOhL+cjIew8W9itGlVIYO21nZYGARnBkQ8cu9Zczbz1K2e79YIzvL/debSxJJ1hFN1BJJxLznZB3RZB05iTqi8TpyYnVEkzFyk1vJSX5GjouRm6wjx8XIc3Xkuhi5LkaklX+nJEbccklYbuNzwnKJR3JJWi6JSB7JSC7JSB7JSBeSkZ4kI7m4/DxcJA8XzcVF80gSIUGUJEYC7++Iu0jjesIZSSLEnXllzitL+GUJzFv3y+udkQSSySTJRAKXTJBMJnDJJC7pnWUk/WXnEtBQ7hKYc0RIEsERtSRGkihJojjMLzfvkwYgYo7cqJEXMXKjRk7UyI0YuRHI9ZdzokaOX9awPdqwHjFyImCRKMlIDs5ySUZySFrOzueGRySXRON61P+8oyQthwQ5JPyypEWJ4y0fOnAYQ/fvf1qzMpYIzKwEOBXoZ2YVwH8CuQDOud8CzwNfA1YB1cAVmYpF9lMyAZ+UwYcLvIp/7T+8X4KRXCg6Hk67FQ461quUI7nUuwi1CahJGDWJCDUJozpuVCegut5brqp37IgbVTFjR72jJp6kqi5BdSxBdSxOdSxBTSxBLJHEVTscfgsCbmdLg2umnNRttThXg2PjzjJ/n1giSSyezi/VKFDoP3YXMSjIjZKfEyE36nW5JR3gx5NMiTHpv7nDL/fjTja0CvnLqX9XAzOvkomYV+k0PlLWI+ZVUtGoEWm6LWLkGORbnHyrp4vFAKhN5lDrcqhJ5lCfhHgS4klHIumIJ5MkEo76hvVEknjSNW5PJPc++e8eM+REI17sjbFCTiTibYtEvL8lArnRCLl5Ea9Cjkb8x+7LOZEIuTlGXspybsTfnhPxlnO8fZ2DmliCKv87Vx2LU1WX2K2sOpagqi5OTW2CKr+sPtGerdQOiHFnoWNo0R533msZSwTOucl72O6A72fq/SU9zrnGL/mOOu8Lv6O2nuTGVXRb9zq9N7zBARvfJj++HYBPCg5jZc/zKc89mnIbyaaqHHaUxqn+e4Lq2HaqYwnie1FBmEHXvBy65EXpmhelS14OXfOidC/IYUCPfHL9SsL8s3Uz2/ncWOaf0FtDM7DtXr7La4zcHCM/x6vA83Mi5OdGyY9GyM/11xu25UbIi0Z3K8/zX5cTzez1Fg1TyVqQbdstcM6lJI2diSJifmUf3b3Sz8a/Y1/F4klqYgmq6+P+j5idiSOR9H4kNHx3I+Yl6kgkZdn/PCJ7sb1319yM/C0drNdJ9sQ5x7aaOBu21bJhWy2fbvWf/cdn2+vYUetV+lV1carrEzgH/djKuMhyToos58Tocg6yjQBUuH48kxjD35NHsTg6ili8L4W1OXR1OXTLj9K7MIei3oUU5kXpmr97he6t51DYsJyfQ5dc77kwz6tUO1Pl0Nay+bMxM/9XeNCRBCPP/0HQk8xUzu1JiaADicWTjRW6V7nXectNKvva+t2bPPp0zeOA7vkM6FHAwX0K6ZMT48jYcoZVlTJk2yL6Vq0CoD63J1sHjWNt0ZdJDDmZ/P6Hck5+LhfnRTP+61dEgqFEkCWSScdn2+tYu7matZuqqdhcw/qtNWzYurPC31gV2+11eTkRBvYoYGCPAkYP7sWA7vkM7FnAgB4FDOzplffvnk9BbhTqtsM/fgur5kPF297VHdF8OORL8IXL4QunkjtwNP0iIf2JJxJSSgTtxDnH5up61m6q9iv7ml0q/XWba4gldv0l37drXmOFXlzUy6vwe+ZzgF/xD+xRQK/C3PSaD9aXw6wpsGk1HHg0jJsGXzjV6+zN7ZKJP1lEOgglgja0oy7uVfSbqlm7ucav5L2Kfu2maqpiiV3271WYS1HvQoYP6s5XRwxgcJ9Cinp3YXDvQgb37uL9it9fzsGi38PcW6GwD0z5Kww5cf+PKyKdhhLBfip5+2NK3v6YtZuq2Vy96w0jXfOiFPXxKvUTvtCXIr+ibyjrXpDhTqbarTBnGqx4Fg47Ey54ELr2y+x7ikiHo0SwHxat2cStzyzjyIE9OGfUIIp6F1LUp4v/XEjvdJttMmHdEnjyCtiyFs68HcZd791+LyLShBLBPtpWW8+NM8oo6lPIE9d8iW75WfJROud1CP/tP6DbALjiBTj4+KCjEpEsliW1V8fz09nL2bCtllnZlARqNsOz18HKv8AR58D5/8/rFxARaUWW1GAdy7Nl65hd9gk3nXkExx7cO+hwPBWlMOsK2P4JnPVfcML3gh1pUUQ6DCWCvVSxuZqfzF7OmEN68/3TDg06HG+Y3rfuh5dvgx4HwpV/g8Fjgo5KRDoQJYK9kEg6fjCzHOfg15ceHfydttWb4Jlr4IO5cOR4mHg/dOkVbEwi0uEoEeyF377yL95es4n/uaSYg/s2Pxplu/n4LXjySqiqhHPuguOmqilIRPaJEkGallZs4dcvvc+5owdx4bHNzqjZPpJJ+Ps9MP9O6HUwXPU3OPCY4OIRkQ5PiSAN1bE4N84oo3/3fP7r/FHB3RuwoxKe+S78ax6MvADOuxcKegYTi4h0GkoEabjjL++yemMVj33neHoWBjTk7JrX4cmrvEtEx/8axlyhpiARaRNKBHvwt3c2UPL2x3z3lC8w7tAAhmdIJuC1/4GF/w19vgCXPwkDR7V/HCLSaSkRtOKz7bXc8vQyRh7Ygx9+ZVj7B7D9U3h6Kqx+BUZdCuN/Bfnd2z8OEenUlAhakEw6bp61lKq6OPdedjR5Oe18qeiHr8BT3/HmEJjwGzjmcjUFiUhGKBG04E9vruHV9yu5Y+JIDjugnX+F12yGxydBryL41rMwYET7vr+IhIqGo2zGexu2898vrOT0Iw/g8hMOaf8Alj8N8Rq48HdKAiKScUoETdTWJ7hhxj/pUZDDLy8eHcylouUlcMAIGFTc/u8tIqGjRNDEXXPfY+WG7dx1cTH9uuW3fwCffwAVi6B4svoERKRdKBGkeO2DSh56fTXfPOEQTjvygGCCKHscLAKjLw3m/UUkdJQIfJurYtw8q5zDDujGj782PJggkglYOhMOPQO6DwwmBhEJHSUCwDnHLU8vZVNVjHsvO5oueW0wafy+WP0qbFsHR08O5v1FJJSUCIAnStcy951Pufmrwxh5YIBj95SXQH5PGHZucDGISOiEPhGs/ryK259bwZe+0JepX/5CcIHUbYd3n4OjLoTcguDiEJHQCXUiqE8kuXFmGbnRCP9zaTGRSIBX6ax4Fuqr4eivBxeDiIRSqO8svm/eB5Sv3cL9Xz+WA3t1CTaYshLocygM/mKwcYhI6IT2jGDRmk3cv2AVFx07mHNHDwo2mM1r4KPXvU5i3TsgIu0slIlgW209N80s46DeXbhtQhYM4VA+EzAYfVnQkYhICIWyaei2Z99h/dZanvjul+heENBEMw2c864WGvplb5A5EZF2Frozgjnln/D0P9dx3WmHMeaQ3kGH401Cv3k1FKuTWESCEapEsG5LDbc+s4xjDu7FtNMPCzocT/njkNsVhp8XdCQiElKhSQSJpOMHM8tIJh33TDqanGgW/OmxanhnNoyYCPndgo5GREIqo7WhmZ1tZu+Z2Sozu6WZ7Qeb2QIz+6eZLTWzr2Uqlt+/9iH/WL2J2yaM5JC+XTP1Nntn5V+hbpuGlBCRQGWss9jMosD9wFeACmCRmc1xzq1I2e0nwBPOuQfMbATwPDAkE/GcNXIgVbEEF48ZnInD75vyx6HnwXDISUFHIiIhlskzguOAVc65D51zMWAGMLHJPg7o4S/3BD7JVDBD+nXlB185IpiJZpqz7RP4cCEUT4JIFjRTiUhoZbIGOghYm7Je4Zelug243Mwq8M4GpjV3IDO72sxKzay0srIyE7G2v6UzwSW9CWhERAIU9E/RycDDzrnBwNeAR81st5icc9Odc2Odc2P79+/f7kG2Oee8ISWKToC+hwYdjYiEXCYTwTog9Q6pwX5ZqquAJwCcc28CBUC/DMaUHT5ZAp+/p05iEckKmUwEi4DDzWyomeUBlwFzmuzzMXAGgJkNx0sEnaTtpxVlJZBTACMvCDoSEZHMJQLnXBy4DpgLvIt3ddA7ZvYzM5vg7/ZDYKqZlQMlwBTnnMtUTFkhXgfLn4Qjz4WCACfBERHxZXSsIefc83idwKllP01ZXgGcmMkYss77c6Fms4aUEJGsEXRncfiUl0C3gXDoaUFHIiICKBG0r6rP4YO/wehLIRINOhoREUCJoH0tmwXJuKajFJGsokTQnsoeh0FHwwHDg45ERKSREkF72bAcNizV2YCIZB0lgvZSXgKRXDjq4qAjERHZhRJBe0jEYekTcMRZ0LVv0NGIiOxCiaA9/GseVH2mAeZEJCspEbSHssehsC8c/tWgIxER2Y0SQabVbIb3nodRl0BOXtDRiIjsRokg05Y/DYmYmoVEJGspEWRaeQkcMAIGFQcdiYhIs5QIMunzD6BikXc2kC1TZIqINKFEkEnlJWARb2whEZEspUSQKckklM+EQ8+A7gODjkZEpEVKBJmy5lXYVqHpKEUk6ykRZEpZCeT3hGHnBh2JiEirlAgyoW47vDsHjroAcguCjkZEpFVKBJmwYg7UV2s6ShHpEJQIMqHscehzKBQdF3QkIiJ7pETQ1javgY9e170DItJhKBG0tfKZgEHxZUFHIiKSFiWCtuScdxPZ0C9Dr6KgoxERSYsSQVv6+C3YvFqdxCLSoSgRtKXyxyG3Kww/L+hIRETSpkTQVupr4J3ZMGIi5HcLOhoRkbQpEbSVlX+Fum0aUkJEOhwlgrZS9jj0PBgOOSnoSERE9ooSQVvYth4+XADFkyCij1REOhbVWm1h6UxwSU1HKSId0h4TgZmdZ2ZKGC1puHeg6Hjoe2jQ0YiI7LV0KvhJwAdm9kszOzLTAXU4n/wTKlfqbEBEOqw9JgLn3OXAMcC/gIfN7E0zu9rMumc8uo6gfAZE82HkBUFHIiKyT9Jq8nHObQOeBGYAg4ALgCVmNi2DsXUMa16HoSdDl15BRyIisk/S6SOYYGbPAAuBXOA459w5QDHww8yGl+Xqa+Hz92BQcdCRiIjss5w09rkI+LVz7tXUQudctZldlZmwOojKlZCMw8BRQUciIrLP0mkaug14u2HFzLqY2RAA59y81l5oZmeb2XtmtsrMbmlhn0vNbIWZvWNmj6cdeTbYsMx7ViIQkQ4snUQwC0imrCf8slaZWRS4HzgHGAFMNrMRTfY5HPh34ETn3EjgxjTjzg4blkFeN+g9NOhIRET2WTqJIMc5F2tY8Zfz0njdccAq59yH/mtmABOb7DMVuN85t9k/9mfphZ0lNiyDAUfpbmIR6dDSqcEqzWxCw4qZTQQ+T+N1BwFrU9Yr/LJURwBHmNnfzewtMzu7uQP5l6uWmllpZWVlGm/dDpJJLxGoWUhEOrh0OouvAR4zs98Ahle5f6sN3/9w4FRgMPCqmY1yzm1J3ck5Nx2YDjB27FjXRu+9f7Z8BLHtSgQi0uHtMRE45/4FnGBm3fz1HWkeex2QOl/jYL8sVQXwD+dcPbDazN7HSwyL0nyP4KijWEQ6iXTOCDCzc4GRQIGZAeCc+9keXrYIONzMhuIlgMuApnM4zgYmA380s354TUUfph19kDYsA4vCAcODjkREZL+kc0PZb/HGG5qG1zR0CXDInl7nnIsD1wFzgXeBJ5xz75jZz1L6HOYCG81sBbAA+Dfn3MZ9+kva24Zl0O8IyO0SdCQiIvslnTOCcc650Wa21Dl3u5n9D/BCOgd3zj0PPN+k7Kcpyw74gf/oWDYsg0PGBR2FiMh+S+eqoVr/udrMDgTq8cYbCq/qTbCtQv0DItIppHNG8JyZ9QLuApYADvhdRqPKduooFpFOpNVE4E9IM8+/nPMpM/sLUOCc29ou0WUrJQIR6URabRpyziXxholoWK8LfRIALxF0PxC69gs6EhGR/ZZOH8E8M7vIGq4bFdiwVGcDItJppJMIvos3yFydmW0zs+1mti3DcWWv+lqofE+JQEQ6jXTuLNaUlKkq3wWXUCIQkU5jj4nAzE5urrzpRDWhoY5iEelk0rl89N9SlgvwhpdeDJyekYiyneYgEJFOJp2mofNS182sCLgnYxFlO81BICKdzL7UZhVAOEdaSyZhw3I1C4lIp5JOH8H/4t1NDF7iOBrvDuPw2bJGcxCISKeTTh9BacpyHChxzv09Q/FkN3UUi0gnlE4ieBKodc4lwJuU3swKnXPVmQ0tC2kOAhHphNK6sxhIHXS/C/ByZsLJcpqDQEQ6oXQSQUHq9JT+cmHmQspimqxeRDqhdBJBlZkd27BiZmOAmsyFlKWqNsK2dUoEItLppNNHcCMwy8w+wZuqciDe1JXh8qk6ikWkc0rnhrJFZnYkMMwves85V5/ZsLJQ4xVDo4ONQ0SkjaUzef33ga7OueXOueVANzP7XuZDyzIblkGPg6Br36AjERFpU+n0EUz1ZygDwDm3GZiauZCylDqKRaSTSicRRFMnpTGzKJCXuZCykOYgEJFOLJ3O4heBmWb2oL/+XeCFzIWUhTQHgYh0Yukkgh8BVwPX+OtL8a4cCg8NLSEindgem4b8Cez/AazBm4vgdODdzIaVZTYsg7zu0GtI0JGIiLS5Fs8IzOwIYLL/+ByYCeCcO619QssiG5bBQM1BICKdU2s120q8X//jnXMnOef+F0i0T1hZRHMQiEgn11oiuBBYDywws9+Z2Rl4dxaHi+YgEJFOrsVE4Jyb7Zy7DDgSWIA31MQBZvaAmX21vQIMnDqKRaSTS6ezuMo597g/d/Fg4J94VxKFQ8McBP01B4GIdE571fvpnNvsnJvunDsjUwFlnQ3LoP8wyC0IOhIRkYzQZTB7oqElRKSTUyJojeYgEJEQUCJojeYgEJEQUCJoTcMVQwOUCESk81IiaI3mIBCREMhoIjCzs83sPTNbZWa3tLLfRWbmzGxsJuPZa+ooFpEQyFgi8OctuB84BxgBTDazEc3s1x24AW9gu+yhOQhEJCQyeUZwHLDKOfehcy4GzAAmNrPfHcD/BWozGMve0xwEIhISmUwEBwFrU9Yr/LJGZnYsUOSc+2trBzKzq82s1MxKKysr2z7S5mhoCREJicA6i80sAvwK+OGe9vXvZh7rnBvbv3//zAcHmoNAREIjk4lgHVCUsj7YL2vQHTgKWGhma4ATgDlZ02GsOQhEJCQyWcstAg43s6FmlgdcBsxp2Oic2+qc6+ecG+KcGwK8BUxwzpVmMKb0aA4CEQmRjCUC51wcuA6Yize15RPOuXfM7GdmNiFT79smNAeBiIRIOpPX7zPn3PPA803KftrCvqdmMpa9oo5iEQkRNYA3R3MQiEiIKBE0R3MQiEiIKBE0R0NLiEiIKBE0pTkIRCRklAia2rDUe1YiEJGQUCJoSnMQiEjIKBE0pTkIRCRklAiaUkexiISMEkGq+hr4/H0lAhEJFSWCVJ9pDgIRCR8lglQaWkJEQkiJIJXmIBCREFIiSKU5CEQkhFTjNUgm4VPNQSAi4aNE0GDzaojtUCIQkdBRImigjmIRCSklggaag0BEQkqJoIHmIBCRkFIiaKChJUQkpJQIAKo+h+2fwMDRQUciItLulAhAHcUiEmpKBKBEICKhpkQA/hwEg6GwT9CRiIi0OyUCUEexiISaEoHmIBCRkFMi0BwEIhJySgTqKBaRkFMi2LAM8ntAr0OCjkREJBBKBBuWwQDNQSAi4RXu2k9zEIiIhDwRaA4CERFygg4gUOoolg6svr6eiooKamtrgw5FskhBQQGDBw8mNzc37dcoEURyoP+RQUcistcqKiro3r07Q4YMwcyCDkeygHOOjRs3UlFRwdChQ9N+XbibhjYsg36ag0A6ptraWvr27askII3MjL59++71WaISgZqFpANTEpCm9uU7Ed5E0DgHgRKBiIRbRhOBmZ1tZu+Z2Sozu6WZ7T8wsxVmttTM5plZ+93VpY5ikTYxe/ZszIyVK1cGHYrso4wlAjOLAvcD5wAjgMlmNqLJbv8ExjrnRgNPAr/MVDy7USIQaRMlJSWcdNJJlJSUZOw9EolExo4tmb1q6DhglXPuQwAzmwFMBFY07OCcW5Cy/1vA5RmMZ1eag0A6kdufe4cVn2xr02OOOLAH/3neyFb32bFjB6+//joLFizgvPPO4/bbbyeRSPCjH/2IF198kUgkwtSpU5k2bRqLFi3ihhtuoKqqivz8fObNm8dTTz1FaWkpv/nNbwAYP348N998M6eeeirdunXju9/9Li+//DL3338/8+fP57nnnqOmpoZx48bx4IMPYmasWrWKa665hsrKSqLRKLNmzeL222/nwgsv5PzzzwfgG9/4BpdeeikTJ05s08+os8hk09BBwNqU9Qq/rCVXAS80t8HMrjazUjMrraysbJvo1FEsst+effZZzj77bI444gj69u3L4sWLmT59OmvWrKGsrIylS5fyjW98g1gsxqRJk7j33nspLy/n5ZdfpkuXLq0eu6qqiuOPP57y8nJOOukkrrvuOhYtWsTy5cupqanhL3/5C+BV8t///vcpLy/njTfeYNCgQVx11VU8/PDDAGzdupU33niDc889N9MfR4eVFfcRmNnlwFjglOa2O+emA9MBxo4d6/b7DRvmIBh+3n4fSiQb7OmXe6aUlJRwww03AHDZZZdRUlLC6tWrueaaa8jJ8aqXPn36sGzZMgYNGsQXv/hFAHr06LHHY0ejUS666KLG9QULFvDLX/6S6upqNm3axMiRIzn11FNZt24dF1xwAeDdTAVwyimn8L3vfY/KykqeeuopLrroosZ4ZHeZ/GTWAUUp64P9sl2Y2ZnArcApzrm6DMazk+YgENlvmzZtYv78+SxbtgwzI5FIYGaNlX06cnJySCaTjeup178XFBQQjUYby7/3ve9RWlpKUVERt9122x6vlf/Wt77Fn//8Z2bMmMEf//jHvfzrwiWTTUOLgMPNbKiZ5QGXAXNSdzCzY4AHgQnOuc8yGMuu1FEsst+efPJJvvnNb/LRRx+xZs0a1q5dy9ChQykuLubBBx8kHo8DXsIYNmwY69evZ9GiRQBs376deDzOkCFDKCsrI5lMsnbtWt5+++1m36uh0u/Xrx87duzgySefBKB79+4MHjyY2bNnA1BXV0d1dTUAU6ZM4Z577gFgxIim16lIqowlAudcHLgOmAu8CzzhnHvHzH5mZhP83e4CugGzzKzMzOa0cLi2pTkIRPZbSUlJY5NMg4suuoj169dz8MEHM3r0aIqLi3n88cfJy8tj5syZTJs2jeLiYr7yla9QW1vLiSeeyNChQxkxYgTXX389xx57bLPv1atXL6ZOncpRRx3FWWedtctZx6OPPsp9993H6NGjGTduHBs2bABgwIABDB8+nCuuuCJzH0InYc7tf5N7exo7dqwrLS3dv4M8dBZYBK5stm9apEN49913GT58eNBhZK3q6mpGjRrFkiVL6NmzZ9DhtKvmvhtmttg5N7a5/cN3Z7HmIBDp9F5++WWGDx/OtGnTQpcE9kX4utE1B4FIp3fmmWfy0UcfBR1GhxG+MwJ1FIuI7CKEiWCp5iAQEUkRwkSgOQhERFKFMxGoWUhEpFG4EsGOSti+XolApA2cdtppzJ07d5eye+65h2uvvbbF15x66qk0XP79ta99jS1btuy2z2233cbdd9/d6nvPnj2bFSsax6/kpz/9KS+//PLehN+qG2+8kYMOOmiXu547s3Algk/VUSzSViZPnsyMGTN2KZsxYwaTJ09O6/XPP/88vXr12qf3bpoIfvazn3HmmWfu07GaSiaTPPPMMxQVFfHKK6+0yTGb03DndTYI1+WjumJIOqsXbtn5/W4rA0fBOb9ocfPFF1/MT37yE2KxGHl5eaxZs4ZPPvmEL3/5y1x77bUsWrSImpoaLr74Ym6//fbdXj9kyMCA6o0AAAx4SURBVBBKS0vp168fP//5z/nTn/7EAQccQFFREWPGjAHgd7/7HdOnTycWi3HYYYfx6KOPUlZWxpw5c3jllVe48847eeqpp7jjjjsYP348F198MfPmzePmm28mHo/zxS9+kQceeID8/HyGDBnCt7/9bZ577jnq6+uZNWsWRx65+0UjCxcuZOTIkUyaNImSkhJOO+00AD799FOuueYaPvzwQwAeeOABxo0bxyOPPMLdd9+NmTF69GgeffRRpkyZ0hgPQLdu3dixYwcLFy7kP/7jP+jduzcrV67k/fff5/zzz2ft2rXU1tZyww03cPXVVwPw4osv8uMf/5hEIkG/fv146aWXGDZsGG+88Qb9+/cnmUxyxBFH8Oabb9K/f//9+qcO1xmB5iAQaTN9+vThuOOO44UXvDv0Z8yYwaWXXoqZ8fOf/5zS0lKWLl3KK6+8wtKlS1s8zuLFi5kxYwZlZWU8//zzjeMRAVx44YUsWrSI8vJyhg8fzkMPPcS4ceOYMGECd911F2VlZRx66KGN+9fW1jJlyhRmzpzJsmXLiMfjPPDAA43b+/Xrx5IlS7j22mtbbH4qKSlh8uTJXHDBBfz1r3+lvr4egOuvv55TTjmF8vJylixZwsiRI3nnnXe48847mT9/PuXl5dx77717/NyWLFnCvffey/vvvw/AH/7wBxYvXkxpaSn33XcfGzdupLKykqlTp/LUU09RXl7OrFmziEQiXH755Tz22GOAd9NccXHxficBCOMZgc4GpDNq5Zd7JjU0D02cOJEZM2bw0EMPAfDEE08wffp04vE469evZ8WKFYwePbrZY7z22mtccMEFFBYWAjBhwoTGbcuXL+cnP/kJW7ZsYceOHZx11lmtxvPee+8xdOhQjjjiCAC+/e1vc//993PjjTcCXmIBGDNmDE8//fRur4/FYjz//PP86le/onv37hx//PHMnTuX8ePHM3/+fB555BHAGyK7Z8+ePPLII1xyySX069cP8JLjnhx33HEMHTq0cf2+++7jmWeeAWDt2rV88MEHVFZWcvLJJzfu13DcK6+8kokTJ3LjjTfyhz/8oc3GUQpPImicg2DCnvcVkbRMnDiRm266iSVLllBdXc2YMWNYvXo1d999N4sWLaJ3795MmTJlj0NGt2TKlCnMnj2b4uJiHn74YRYuXLhf8ebn5wNeRd5cG/3cuXPZsmULo0Z5Pxirq6vp0qUL48eP36v3SR1eO5lMEovFGrd17dq1cXnhwoW8/PLLvPnmmxQWFnLqqae2+lkVFRUxYMAA5s+fz9tvv914drC/wtM09NkKcEmdEYi0oW7dunHaaadx5ZVXNnYSb9u2ja5du9KzZ08+/fTTxqajlpx88snMnj2bmpoatm/fznPPPde4bfv27QwaNIj6+vpdKr3u3buzffv23Y41bNgw1qxZw6pVqwBvZNJTTml2vqtmlZSU8Pvf/541a9awZs0aVq9ezUsvvUR1dTVnnHFGYzNTIpFg69atnH766cyaNYuNGzcC3pDb4PV/LF68GIA5c+Y0Ni81tXXrVnr37k1hYSErV67krbfeAuCEE07g1VdfZfXq1bscF+A73/kOl19+OZdccknjfA37KzyJQB3FIhkxefJkysvLGxNBcXExxxxzDEceeSRf//rXOfHEE1t9/bHHHsukSZMoLi7mnHPO2WWI6TvuuIPjjz+eE088cZeO3csuu4y77rqLY445hn/961+N5QUFBfzxj3/kkksuYdSoUUQiEa655pq0/o7q6mpefPHFXaa07Nq1KyeddBLPPfcc9957LwsWLGDUqFGMGTOGFStWMHLkSG699VZOOeUUiouL+cEPfgDA1KlTeeWVVyguLubNN9/c5Swg1dlnn008Hmf48OHccsstnHDCCQD079+f6dOnc+GFF1JcXMykSZMaXzNhwgR27NjRpsNrh2cY6pV/hX8+BpP+DJHw5D/pvDQMdTiVlpZy00038dprr7W4z94OQx2ePoIjz/UeIiId1C9+8QseeOCBNusbaKCfxiIiHcQtt9zCRx99xEknndSmx1UiEOnAOlrTrmTevnwnlAhEOqiCggI2btyoZCCNnHNs3LiRgoK9G105PH0EIp3M4MGDqaiooLKyMuhQJIsUFBQwePDgvXqNEoFIB5Wbm7vLHaoi+0pNQyIiIadEICISckoEIiIh1+HuLDazSuCjfXx5P+DzNgwn0zpSvB0pVuhY8XakWKFjxduRYoX9i/cQ51yzY1Z3uESwP8ystKVbrLNRR4q3I8UKHSvejhQrdKx4O1KskLl41TQkIhJySgQiIiEXtkQwPegA9lJHircjxQodK96OFCt0rHg7UqyQoXhD1UcgIiK7C9sZgYiINKFEICIScqFJBGZ2tpm9Z2arzOyWoONpiZkVmdkCM1thZu+Y2Q1Bx5QOM4ua2T/N7C9Bx9IaM+tlZk+a2Uoze9fMvhR0TK0xs5v878FyMysxs70bVjLDzOwPZvaZmS1PKetjZi+Z2Qf+c+8gY2zQQqx3+d+FpWb2jJn1CjLGBs3FmrLth2bmzKxfW71fKBKBmUWB+4FzgBHAZDMbEWxULYoDP3TOjQBOAL6fxbGmugF4N+gg0nAv8KJz7kigmCyO2cwOAq4HxjrnjgKiwGXBRrWbh4Gzm5TdAsxzzh0OzPPXs8HD7B7rS8BRzrnRwPvAv7d3UC14mN1jxcyKgK8CH7flm4UiEQDHAauccx8652LADGBiwDE1yzm33jm3xF/ejldRHRRsVK0zs8HAucDvg46lNWbWEzgZeAjAORdzzm0JNqo9ygG6mFkOUAh8EnA8u3DOvQpsalI8EfiTv/wn4Px2DaoFzcXqnPubcy7ur74F7N34zRnSwucK8Gvg/wBtepVPWBLBQcDalPUKsrxyBTCzIcAxwD+CjWSP7sH7ciaDDmQPhgKVwB/9Zqzfm1nXoINqiXNuHXA33q+/9cBW59zfgo0qLQOcc+v95Q3AgCCD2QtXAi8EHURLzGwisM45V97Wxw5LIuhwzKwb8BRwo3NuW9DxtMTMxgOfOecWBx1LGnKAY4EHnHPHAFVkT7PFbvy29Yl4CexAoKuZXR5sVHvHedenZ/016mZ2K16zbNvOCt9GzKwQ+DHw00wcPyyJYB1QlLI+2C/LSmaWi5cEHnPOPR10PHtwIjDBzNbgNbmdbmZ/DjakFlUAFc65hjOsJ/ESQ7Y6E1jtnKt0ztUDTwPjAo4pHZ+a2SAA//mzgONplZlNAcYD33DZe2PVoXg/CMr9/2uDgSVmNrAtDh6WRLAIONzMhppZHl6H25yAY2qWmRleG/a7zrlfBR3Pnjjn/t05N9g5NwTvc53vnMvKX63OuQ3AWjMb5hedAawIMKQ9+Rg4wcwK/e/FGWRx53aKOcC3/eVvA88GGEurzOxsvGbNCc656qDjaYlzbplz7gDn3BD//1oFcKz/nd5voUgEfmfQdcBcvP9ITzjn3gk2qhadCHwT75d1mf/4WtBBdSLTgMfMbClwNPBfAcfTIv/M5UlgCbAM7/9rVg2JYGYlwJvAMDOrMLOrgF8AXzGzD/DOan4RZIwNWoj1N0B34CX//9pvAw3S10KsmXu/7D0TEhGR9hCKMwIREWmZEoGISMgpEYiIhJwSgYhIyCkRiIiEnBKBiM/MEimX7Ja15Si1ZjakuZEkRbJBTtABiGSRGufc0UEHIdLedEYgsgdmtsbMfmlmy8zsbTM7zC8fYmbz/bHs55nZwX75AH9s+3L/0TAsRNTMfufPL/A3M+vi73+9P//EUjObEdCfKSGmRCCyU5cmTUOTUrZtdc6NwrsT9R6/7H+BP/lj2T8G3OeX3we84pwrxhvLqOEu9sOB+51zI4EtwEV++S3AMf5xrsnUHyfSEt1ZLOIzsx3OuW7NlK8BTnfOfegPCLjBOdfXzD4HBjnn6v3y9c65fmZWCQx2ztWlHGMI8JI/WQtm9iMg1zl3p5m9COwAZgOznXM7MvyniuxCZwQi6XEtLO+NupTlBDv76M7Fm0HvWGCRPwmNSLtRIhBJz6SU5zf95TfYOXXkN4DX/OV5wLXQOJdzz5YOamYRoMg5twD4EdAT2O2sRCST9MtDZKcuZlaWsv6ic67hEtLe/oildcBkv2wa3mxn/4Y389kVfvkNwHR/xMgEXlJYT/OiwJ/9ZGHAfR1g+kzpZNRHILIHfh/BWOfc50HHIpIJahoSEQk5nRGIiISczghEREJOiUBEJOSUCEREQk6JQEQk5JQIRERC7v8DcrgJzso6rbIAAAAASUVORK5CYII=\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "bcXU-LWXgaaA"
+      },
+      "source": [
+        "model.save('CNN.h5')"
+      ],
+      "execution_count": 27,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "aA4B7Y9jEPN1",
-        "colab_type": "code",
-        "colab": {}
+        "id": "aA4B7Y9jEPN1"
       },
       "source": [
         "predictions=[]\n",
@@ -431,16 +1257,14 @@
         "    a=np.where(y_pred[i] == max(y_pred[i]))\n",
         "    predictions.append(a[0][0])"
       ],
-      "execution_count": null,
+      "execution_count": 48,
       "outputs": []
     },
     {
       "cell_type": "code",
       "metadata": {
         "trusted": true,
-        "id": "IWusfenIEPN5",
-        "colab_type": "code",
-        "colab": {}
+        "id": "IWusfenIEPN5"
       },
       "source": [
         "import pandas as pd\n",
@@ -448,8 +1272,209 @@
         "solution = pd.DataFrame({\"ImageId\": counter, \"label\": list(predictions)})\n",
         "solution.to_csv(\"digit_recognizer8.csv\", index = False)"
       ],
-      "execution_count": null,
+      "execution_count": 49,
       "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aJ5VAQEBpz7z"
+      },
+      "source": [
+        "## Python file"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Intqpwugp1Gb"
+      },
+      "source": [
+        "import tensorflow as tf\n",
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "import cv2"
+      ],
+      "execution_count": 10,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "5BFfAtz7qFW6",
+        "outputId": "b99b81f9-d074-4127-e36e-77d574d1ac28"
+      },
+      "source": [
+        "filename = input(\"Enter image filename (with extension)\\n\")"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Enter image filename (with extension)\n",
+            "num.png\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "mNsEmoOrqvcY"
+      },
+      "source": [
+        "img = cv2.resize(plt.imread(filename),(28,28))"
+      ],
+      "execution_count": 23,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 282
+        },
+        "id": "r_xZIwdJrU9b",
+        "outputId": "52d5dfe7-1919-487b-effb-cd6b01cd91d3"
+      },
+      "source": [
+        "plt.imshow(img)"
+      ],
+      "execution_count": 24,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "<matplotlib.image.AxesImage at 0x7f1924ddf810>"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 24
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPsAAAD4CAYAAAAq5pAIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAANe0lEQVR4nO3dX6hd9ZnG8edJbFFsLhL/xGhOTKYEtY5MMiRhIDFkKCkakaQEpbkoqcicXlRpIRcVe1EvdZhaBsHCKUrTIWOpRDFCGRtDIEYhJJGoiZn8kxOaeEysUXqKaCfmnYuzUo561m8f9/+T9/uBw957vXvt/bLJk7X2+q29fo4IAbj0Tet1AwC6g7ADSRB2IAnCDiRB2IEkLuvmm9nm0D/QYRHhiZa3tGW3fYftI7aP236oldcC0Fludpzd9nRJRyWtlnRK0l5JGyLi7cI6bNmBDuvEln2ZpOMR8U5E/E3S7yStbeH1AHRQK2G/QdKfxj0+VS37HNuDtvfZ3tfCewFoUccP0EXEkKQhid14oJda2bKfljQw7vHcahmAPtRK2PdKWmh7ge2vS/qepG3taQtAuzW9Gx8R520/IOklSdMlPR0Rh9rWGYC2anrorak34zs70HEdOakGwNRB2IEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Ig7EASXZ2yeSpbv359bW1wcLC47rvvvlusf/LJJ8X6li1bivUzZ87U1o4dO1ZcF3mwZQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJJjFdZJOnjxZWxsYGOhiJ182OjpaWzt0KO8s2qdOnaqtPfbYY8V19+/f3+52uqZuFteWTqqxPSxpVNJnks5HxJJWXg9A57TjDLp/jYg/t+F1AHQQ39mBJFoNe0j6o+39tic8Qdz2oO19tve1+F4AWtDqbvyKiDht+1pJ223/b0TsGv+EiBiSNCRN7QN0wFTX0pY9Ik5Xt2clPS9pWTuaAtB+TYfd9pW2Z1y8L+k7kg62qzEA7dXKbvxsSc/bvvg6/x0R/9OWrvrQE088UVu7+eabi+sODw8X6/Pnzy/W582bV6zfdttttbVbbrmluO4HH3xQrF911VXFeisanePx0UcfFeszZ84s1m+66abaWqNx9Kk8zl6n6bBHxDuS/qmNvQDoIIbegCQIO5AEYQeSIOxAEoQdSIJLSU/SK6+8Uls7d+5ccd3jx48X640uNd1oCOryyy+vrV177bXFdUdGRor18+fPF+utaDT09v777xfrc+fOLdYvu6z+n/eMGTOK616K2LIDSRB2IAnCDiRB2IEkCDuQBGEHkiDsQBKMs0/Snj17mqpNxq5duxo/qWDWrFm1tcWLFxfX3bt3b7G+dOnSpnqajE8//bRYb3QZ7KNHjxbrpZ/nlqa5vlSxZQeSIOxAEoQdSIKwA0kQdiAJwg4kQdiBJJiyGX1r/fr1xfqzzz5brJfG6VeuXFlc98MPPyzW+1ndlM1s2YEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcbZ0TPXXXddsf7GG28U69dcc02xfs8999TWtm7dWlx3Kmt6nN3207bP2j44btks29ttH6tuyxNlA+i5yezG/0bSHV9Y9pCkHRGxUNKO6jGAPtYw7BGxS9IX5zdaK2lzdX+zpHVt7gtAmzV7DbrZEXFxkrD3JM2ue6LtQUmDTb4PgDZp+YKTERGlA28RMSRpSOIAHdBLzQ69nbE9R5Kq27PtawlAJzQb9m2SNlb3N0p6oT3tAOiUhrvxtp+RtErS1bZPSfq5pEcl/d72/ZJOSrq3k03i0vTggw8W643G0UdHR4v1w4cPf+WeLmUNwx4RG2pK325zLwA6iNNlgSQIO5AEYQeSIOxAEoQdSIKfuKKjVqxYUVvbuXNncd3p06cX66tWrSrWW50Ke6riUtJAcoQdSIKwA0kQdiAJwg4kQdiBJAg7kETLV6oBSu68887a2rRp5W3N9u3bi/XXXnutqZ6yYssOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0kwzo6WXHHFFcX6ypUra2sXLlworvvkk08W6+fPny/W8Xls2YEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcbZ0ZKlS5cW6/PmzautDQ8PF9c9dOhQMy2hRsMtu+2nbZ+1fXDcskdsn7Z9oPpb09k2AbRqMrvxv5F0xwTLfxkRi6q/P7S3LQDt1jDsEbFL0rku9AKgg1o5QPeA7Ter3fyZdU+yPWh7n+19LbwXgBY1G/ZfSfqmpEWSRiT9ou6JETEUEUsiYkmT7wWgDZoKe0SciYjPIuKCpF9LWtbetgC0W1Nhtz1n3MPvSjpY91wA/aHhOLvtZyStknS17VOSfi5ple1FkkLSsKQfdrBH9LHly5cX6wMDA7W1l156qbju8ePHm+oJE2sY9ojYMMHipzrQC4AO4nRZIAnCDiRB2IEkCDuQBGEHknBEdO/N7O69Gdri7rvvLtafe+65Yv3jjz+urd11113FdXfv3l2sY2IR4YmWs2UHkiDsQBKEHUiCsANJEHYgCcIOJEHYgSS4lHRys2bNKtYff/zxYn3atPL2ovQzVsbRu4stO5AEYQeSIOxAEoQdSIKwA0kQdiAJwg4kwe/Zk9u/f3+xvnjx4mL9xIkTxfqaNfUT/B47dqy4LprD79mB5Ag7kARhB5Ig7EAShB1IgrADSRB2IAnG2S9xCxcuLNaPHDnS0uuvXbu2WH/xxRdben18dU2Ps9sesL3T9tu2D9n+cbV8lu3tto9VtzPb3TSA9pnMbvx5SZsi4luS/kXSj2x/S9JDknZExEJJO6rHAPpUw7BHxEhEvF7dH5V0WNINktZK2lw9bbOkdZ1qEkDrvtI16GzPl7RY0h5JsyNipCq9J2l2zTqDkgabbxFAO0z6aLztb0jaKuknEfGX8bUYO8o34cG3iBiKiCURsaSlTgG0ZFJht/01jQV9S0RcnLbzjO05VX2OpLOdaRFAOzTcjbdtSU9JOhwR468rvE3SRkmPVrcvdKRDNHTjjTfW1l5++eWWXnvTpk3FOkNrU8dkvrMvl/R9SW/ZPlAte1hjIf+97fslnZR0b2daBNAODcMeEbslTThIL+nb7W0HQKdwuiyQBGEHkiDsQBKEHUiCsANJMGXzJeC+++6rrV1//fXFdRv9xPnVV19tqif0H7bsQBKEHUiCsANJEHYgCcIOJEHYgSQIO5AE4+xTwK233lqsr1tXf/m/adPK/5+PXa6g3oULF4p1TB1s2YEkCDuQBGEHkiDsQBKEHUiCsANJEHYgCcbZp4CZM8sT5C5YsKBLnWAqY8sOJEHYgSQIO5AEYQeSIOxAEoQdSIKwA0lMZn72AUm/lTRbUkgaioj/tP2IpH+T9H711Icj4g+dajSz22+/vVifMWNGba3RdeFPnDhRrI+OjhbrmDomc1LNeUmbIuJ12zMk7be9var9MiL+o3PtAWiXyczPPiJppLo/avuwpBs63RiA9vpK39ltz5e0WNKeatEDtt+0/bTtCc/ptD1oe5/tfS11CqAlkw677W9I2irpJxHxF0m/kvRNSYs0tuX/xUTrRcRQRCyJiCVt6BdAkyYVdttf01jQt0TEc5IUEWci4rOIuCDp15KWda5NAK1qGHaPXX70KUmHI+LxccvnjHvadyUdbH97ANplMkfjl0v6vqS3bB+olj0saYPtRRobjhuW9MOOdIiWHDhwoFhfvXp1sX7u3Ll2toMemszR+N2SJrq4OGPqwBTCGXRAEoQdSIKwA0kQdiAJwg4kQdiBJNzoJ5BtfTO7e28GJBURE87DzZYdSIKwA0kQdiAJwg4kQdiBJAg7kARhB5Lo9pTNf5Z0ctzjq6tl/ahfe+vXviR6a1Y7e7uxrtDVk2q+9Ob2vn69Nl2/9tavfUn01qxu9cZuPJAEYQeS6HXYh3r8/iX92lu/9iXRW7O60ltPv7MD6J5eb9kBdAlhB5LoSdht32H7iO3jth/qRQ91bA/bfsv2gV7PT1fNoXfW9sFxy2bZ3m77WHU74Rx7PertEdunq8/ugO01PeptwPZO22/bPmT7x9Xynn52hb668rl1/Tu77emSjkpaLemUpL2SNkTE211tpIbtYUlLIqLnJ2DYXinpr5J+GxH/WC37d0nnIuLR6j/KmRHx0z7p7RFJf+31NN7VbEVzxk8zLmmdpB+oh59doa971YXPrRdb9mWSjkfEOxHxN0m/k7S2B330vYjYJemLU7KslbS5ur9ZY/9Yuq6mt74QESMR8Xp1f1TSxWnGe/rZFfrqil6E/QZJfxr3+JT6a773kPRH2/ttD/a6mQnMjoiR6v57kmb3spkJNJzGu5u+MM1433x2zUx/3ioO0H3Zioj4Z0l3SvpRtbval2LsO1g/jZ1OahrvbplgmvG/6+Vn1+z0563qRdhPSxoY93hutawvRMTp6vaspOfVf1NRn7k4g251e7bH/fxdP03jPdE04+qDz66X05/3Iux7JS20vcD21yV9T9K2HvTxJbavrA6cyPaVkr6j/puKepukjdX9jZJe6GEvn9Mv03jXTTOuHn92PZ/+PCK6/idpjcaOyJ+Q9LNe9FDT1z9IeqP6O9Tr3iQ9o7Hduv/T2LGN+yVdJWmHpGOSXpY0q496+y9Jb0l6U2PBmtOj3lZobBf9TUkHqr81vf7sCn115XPjdFkgCQ7QAUkQdiAJwg4kQdiBJAg7kARhB5Ig7EAS/w96V0DPqspBeQAAAABJRU5ErkJggg==\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "0RoeSQqftlBO"
+      },
+      "source": [
+        "from keras.models import load_model\n",
+        "model = load_model('CNN.h5')"
+      ],
+      "execution_count": 25,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "gqzr-I7ztzfh",
+        "outputId": "d95a992d-5b6c-4650-9435-65bd3c20c0ec"
+      },
+      "source": [
+        "img.shape"
+      ],
+      "execution_count": 29,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(28, 28, 4)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 29
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "sGCoqP3YuXXB"
+      },
+      "source": [
+        "def rgb2gray(rgb):\n",
+        "    r, g, b = rgb[:,:,0], rgb[:,:,1], rgb[:,:,2]\n",
+        "    gray = 0.2989 * r + 0.5870 * g + 0.1140 * b\n",
+        "    return gray"
+      ],
+      "execution_count": 31,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "4BCfyLoKuaLE",
+        "outputId": "982777c2-5ca9-4fc8-9b0a-05b07a1ca5ed"
+      },
+      "source": [
+        "img_grayscale = rgb2gray(img).reshape(1,28,28,1)\n",
+        "img_grayscale.shape"
+      ],
+      "execution_count": 39,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(1, 28, 28, 1)"
+            ]
+          },
+          "metadata": {},
+          "execution_count": 39
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "RfbikzExtqgY",
+        "outputId": "59348bd5-b985-4a94-90c8-e19856246959"
+      },
+      "source": [
+        "pred = model.predict(img_grayscale)\n",
+        "print(\"Prediction: \", np.argmax(pred),\"\\n Confidence: \", pred[0,np.argmax(pred)])"
+      ],
+      "execution_count": 46,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Prediction:  7 \n",
+            " Confidence:  0.9999759\n"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/mnist-classifier.py
+++ b/mnist-classifier.py
@@ -1,0 +1,26 @@
+import tensorflow as tf
+import numpy as np
+import matplotlib.pyplot as plt
+import cv2
+
+filename = input("Enter image filename (with extension)\n")
+
+img = cv2.resize(plt.imread(filename),(28,28))
+
+
+from keras.models import load_model
+model = load_model('CNN.h5')
+
+
+
+def rgb2gray(rgb):
+    r, g, b = rgb[:,:,0], rgb[:,:,1], rgb[:,:,2]
+    gray = 0.2989 * r + 0.5870 * g + 0.1140 * b
+    return gray
+
+img_grayscale = rgb2gray(img).reshape(1,28,28,1)
+
+
+pred = model.predict(img_grayscale)
+print("Prediction: ", np.argmax(pred),"\n Confidence: ", pred[0,np.argmax(pred)])
+input()


### PR DESCRIPTION
Added Python file for digit classification by just entering the filename for RGB image (can be of anysize, should be placed in same folder as `mnist-classifier.py` )

For the notebook:
- Got around 98% training and validation accuracy
- Data extracted from Kaggle
- Changed batch-size to match dataset dimensions
- Saved model file as `CNN.h5`
- Plotted Accuracy and Loss
- Added section for Python (.py) file
